### PR TITLE
fix: guard event date formatting and use getOrganizerEvents only

### DIFF
--- a/eventpro-frontend/src/components/EventCard.tsx
+++ b/eventpro-frontend/src/components/EventCard.tsx
@@ -13,8 +13,16 @@ interface EventCardProps {
   index?: number;
 }
 
+function safeFormatDate(value: string | undefined, formatStr: string, fallback: string): string {
+  const raw = value;
+  const d = raw ? new Date(raw) : null;
+  if (!d || Number.isNaN(d.getTime())) return fallback;
+  return format(d, formatStr);
+}
+
 export const EventCard = ({ event, index = 0 }: EventCardProps) => {
   const navigate = useNavigate();
+  const startRaw = event.startTime ?? event.startDateTime;
 
   const getStatusColor = (status: Event["status"]) => {
     switch (status) {
@@ -134,10 +142,10 @@ export const EventCard = ({ event, index = 0 }: EventCardProps) => {
               </div>
               <div>
                 <p className="font-medium text-foreground">
-                  {format(new Date(event.startTime || event.startDateTime || new Date()), "EEEE, MMM d")}
+                  {safeFormatDate(startRaw, "EEEE, MMM d", "Date TBD")}
                 </p>
                 <p className="text-muted-foreground text-xs">
-                  {format(new Date(event.startTime || event.startDateTime || new Date()), "yyyy")}
+                  {safeFormatDate(startRaw, "yyyy", "—")}
                 </p>
               </div>
             </div>
@@ -147,7 +155,7 @@ export const EventCard = ({ event, index = 0 }: EventCardProps) => {
                 <Clock className="h-4 w-4 text-primary" />
               </div>
               <p className="font-medium text-foreground">
-                {format(new Date(event.startTime || event.startDateTime || new Date()), "h:mm a")}
+                {safeFormatDate(startRaw, "h:mm a", "Time TBD")}
               </p>
             </div>
 

--- a/eventpro-frontend/src/components/RecentlyViewedEvents.tsx
+++ b/eventpro-frontend/src/components/RecentlyViewedEvents.tsx
@@ -51,7 +51,12 @@ export const RecentlyViewedEvents: React.FC<RecentlyViewedEventsProps> = ({
                 <CardDescription className="space-y-1">
                   <div className="flex items-center gap-1 text-xs">
                     <Calendar className="h-3 w-3" />
-                    {format(new Date(event.startDateTime), "MMM d, yyyy")}
+                    {(() => {
+                      const raw = event.startTime ?? event.startDateTime;
+                      const d = raw ? new Date(raw) : null;
+                      if (!d || Number.isNaN(d.getTime())) return "Date TBD";
+                      return format(d, "MMM d, yyyy");
+                    })()}
                   </div>
                   {event.venue && (
                     <div className="flex items-center gap-1 text-xs">

--- a/eventpro-frontend/src/pages/EventDetails.tsx
+++ b/eventpro-frontend/src/pages/EventDetails.tsx
@@ -152,11 +152,25 @@ const EventDetails = () => {
               <div className="flex flex-wrap gap-4 text-muted-foreground mb-6">
                 <div className="flex items-center gap-2">
                   <Calendar className="h-5 w-5" />
-                  <span>{format(new Date(event.startDateTime), "PPPP")}</span>
+                  <span>
+                    {(() => {
+                      const raw = event.startTime ?? event.startDateTime;
+                      const d = raw ? new Date(raw) : null;
+                      if (!d || Number.isNaN(d.getTime())) return "Date TBD";
+                      return format(d, "PPPP");
+                    })()}
+                  </span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Clock className="h-5 w-5" />
-                  <span>{format(new Date(event.startDateTime), "p")}</span>
+                  <span>
+                    {(() => {
+                      const raw = event.startTime ?? event.startDateTime;
+                      const d = raw ? new Date(raw) : null;
+                      if (!d || Number.isNaN(d.getTime())) return "Time TBD";
+                      return format(d, "p");
+                    })()}
+                  </span>
                 </div>
                 {event.venue && (
                   <div className="flex items-center gap-2">

--- a/eventpro-frontend/src/pages/Organizer.tsx
+++ b/eventpro-frontend/src/pages/Organizer.tsx
@@ -26,13 +26,8 @@ const Organizer = () => {
   const loadEvents = async () => {
     try {
       setIsLoading(true);
-      const [drafts, allEvents] = await Promise.all([
-        apiService.getOrganizerDraftEvents(),
-        apiService.getOrganizerEvents(),
-      ]);
-
-      setDraftEvents(drafts);
-      // Filter to get only published events
+      const allEvents = await apiService.getOrganizerEvents();
+      setDraftEvents(allEvents.filter(e => e.status === "DRAFT"));
       setPublishedEvents(allEvents.filter(e => e.status === "PUBLISHED"));
     } catch (error: any) {
       console.error("Failed to load events:", error);


### PR DESCRIPTION
- Use startTime/startDateTime with fallback and validate before format() in EventDetails, EventCard, RecentlyViewedEvents to avoid RangeError
- Load organizer dashboard from getOrganizerEvents() and filter draft/published client-side (remove getOrganizerDraftEvents)