### PR TITLE
feat(subscription): seamless sync flow, current-plan UX on Pricing, upgrade email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# Copy to .env and fill in. Used by Docker Compose and local backend.
+# Generate JWT keys: make jwt-keys
+# See docs/VARIABLES.md for full list.
+
+# -----------------------------------------------------------------------------
+# JWT (required for backend auth – run: make jwt-keys)
+# -----------------------------------------------------------------------------
+JWT_ISSUER=eventpro
+JWT_ACCESS_TTL_SECONDS=3600
+JWT_PUBLIC_KEY=
+JWT_PRIVATE_KEY=
+
+# -----------------------------------------------------------------------------
+# Database (Docker Compose overrides with postgres host)
+# -----------------------------------------------------------------------------
+# DB_URL=jdbc:postgresql://postgres:5432/eventpro
+# DB_USERNAME=eventpro
+# DB_PASSWORD=eventpro
+
+# -----------------------------------------------------------------------------
+# AWS / LocalStack (queue URLs from make local-infra or Terraform)
+# -----------------------------------------------------------------------------
+S3_BUCKET_NAME=eventpro-images-local
+ORDER_QUEUE_URL=http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/order-queue
+PAYMENT_QUEUE_URL=http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/payment-queue
+NOTIFICATION_QUEUE_URL=http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/notification-queue
+
+# -----------------------------------------------------------------------------
+# Stripe (required to test upgrade: secret + publishable + Price IDs)
+# Test keys: https://dashboard.stripe.com/test/apikeys
+# Price IDs: Dashboard → Products → open product → copy Price ID (must be price_xxx, not prod_xxx)
+# -----------------------------------------------------------------------------
+STRIPE_SECRET_KEY=
+STRIPE_PUBLISHABLE_KEY=
+# STRIPE_WEBHOOK_SECRET=whsec_...   # for subscription webhooks (invoice.paid, etc.)
+STRIPE_PRICE_PRO_MONTHLY=
+STRIPE_PRICE_PRO_YEARLY=
+STRIPE_PRICE_ENTERPRISE_MONTHLY=
+STRIPE_PRICE_ENTERPRISE_YEARLY=

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ vite.config.*.timestamp-*
 
 ## Environment variables
 .env
+.env.stripe
 .env.backup
 .env.local
 .env.*.local

--- a/backend/services/modules/eventpro-api/build.gradle
+++ b/backend/services/modules/eventpro-api/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // PDF generation (1099-K)
     implementation 'org.apache.pdfbox:pdfbox:2.0.29'
 
+    // Stripe (webhook controller and subscription checkout use Stripe types directly)
+    implementation 'com.stripe:stripe-java:24.16.0'
+
     // Lombok
     compileOnly "org.projectlombok:lombok:${project.ext.lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${project.ext.lombokVersion}"

--- a/backend/services/modules/eventpro-api/build.gradle
+++ b/backend/services/modules/eventpro-api/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     // Spring Boot DevTools (for hot reload in development)
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     
+    // PDF generation (1099-K)
+    implementation 'org.apache.pdfbox:pdfbox:2.0.29'
+
     // Lombok
     compileOnly "org.projectlombok:lombok:${project.ext.lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${project.ext.lombokVersion}"

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/PlatformFeeConfig.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/PlatformFeeConfig.java
@@ -1,0 +1,26 @@
+package com.accessplus.eventpro.api.config;
+
+import com.accessplus.eventpro.order.order.config.PlatformFeeProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.math.BigDecimal;
+
+/**
+ * Provides platform fee rates at order creation. We use 0 here because actual fees
+ * are tier-based (Basic 3.5%+$0.99, Pro 2.9%+$0.79, Enterprise 2.5%+$0.49) and computed
+ * per organizer at report time (dashboard, 1099-K). Order-level platform_fee is left 0.
+ */
+@Configuration
+public class PlatformFeeConfig {
+
+    @Bean
+    public PlatformFeeProvider platformFeeProvider() {
+        return new PlatformFeeProvider() {
+            @Override
+            public double getFeePercent() { return 0; }
+            @Override
+            public BigDecimal getFeePerTicket() { return BigDecimal.ZERO; }
+        };
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/PlatformTierFeeProperties.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/PlatformTierFeeProperties.java
@@ -1,0 +1,54 @@
+package com.accessplus.eventpro.api.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+/**
+ * Platform fee by subscription tier. Must match the Pricing page:
+ * Basic 3.5% + $0.99, Pro 2.9% + $0.79, Enterprise 2.5% + $0.49 per ticket.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "eventpro.platform.tiers")
+public class PlatformTierFeeProperties {
+
+    private TierFee basic = new TierFee(3.5, "0.99");
+    private TierFee pro = new TierFee(2.9, "0.79");
+    private TierFee enterprise = new TierFee(2.5, "0.49");
+
+    @Data
+    public static class TierFee {
+        private double feePercent;
+        private BigDecimal feePerTicket = BigDecimal.ZERO;
+
+        public TierFee() {}
+
+        public TierFee(double feePercent, String feePerTicket) {
+            this.feePercent = feePercent;
+            this.feePerTicket = new BigDecimal(feePerTicket);
+        }
+    }
+
+    /** Returns fee percent for tier (BASIC, PRO, ENTERPRISE). Defaults to Basic if unknown. */
+    public double getFeePercentForTier(String tier) {
+        if (tier == null) return basic.getFeePercent();
+        return switch (tier.toUpperCase()) {
+            case "PRO" -> pro.getFeePercent();
+            case "ENTERPRISE" -> enterprise.getFeePercent();
+            default -> basic.getFeePercent();
+        };
+    }
+
+    /** Returns fee per ticket for tier. Defaults to Basic if unknown. */
+    public BigDecimal getFeePerTicketForTier(String tier) {
+        if (tier == null) return basic.getFeePerTicket() != null ? basic.getFeePerTicket() : BigDecimal.ZERO;
+        return switch (tier.toUpperCase()) {
+            case "PRO" -> pro.getFeePerTicket() != null ? pro.getFeePerTicket() : BigDecimal.ZERO;
+            case "ENTERPRISE" -> enterprise.getFeePerTicket() != null ? enterprise.getFeePerTicket() : BigDecimal.ZERO;
+            default -> basic.getFeePerTicket() != null ? basic.getFeePerTicket() : BigDecimal.ZERO;
+        };
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/StripeSubscriptionConfig.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/StripeSubscriptionConfig.java
@@ -1,0 +1,41 @@
+package com.accessplus.eventpro.api.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Stripe subscription price IDs. Create Products and Prices in Stripe Dashboard,
+ * then set STRIPE_PRICE_PRO_MONTHLY etc. in env.
+ */
+@Configuration
+@Getter
+public class StripeSubscriptionConfig {
+
+    @Value("${stripe.subscription.priceIdProMonthly:}")
+    private String priceIdProMonthly;
+
+    @Value("${stripe.subscription.priceIdProYearly:}")
+    private String priceIdProYearly;
+
+    @Value("${stripe.subscription.priceIdEnterpriseMonthly:}")
+    private String priceIdEnterpriseMonthly;
+
+    @Value("${stripe.subscription.priceIdEnterpriseYearly:}")
+    private String priceIdEnterpriseYearly;
+
+    public String getPriceId(String tier, String period) {
+        boolean yearly = "YEARLY".equalsIgnoreCase(period);
+        return switch (tier != null ? tier.toUpperCase() : "PRO") {
+            case "ENTERPRISE" -> yearly ? priceIdEnterpriseYearly : priceIdEnterpriseMonthly;
+            default -> yearly ? priceIdProYearly : priceIdProMonthly;
+        };
+    }
+
+    /** Derive tier from a Stripe Price ID (for webhook and sync). */
+    public String getTierFromPriceId(String priceId) {
+        if (priceId == null || priceId.isBlank()) return "PRO";
+        if (priceId.equals(priceIdEnterpriseMonthly) || priceId.equals(priceIdEnterpriseYearly)) return "ENTERPRISE";
+        return "PRO";
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/TaxProperties.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/config/TaxProperties.java
@@ -1,0 +1,30 @@
+package com.accessplus.eventpro.api.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Sales tax configuration: default rate and optional per-state rates (US).
+ * Used for jurisdiction-based tax at checkout; pass buyer state to checkout-totals.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "eventpro.tax")
+public class TaxProperties {
+
+    /** Fallback rate when no state or state not in map (0 = no tax). */
+    private double defaultRate = 0;
+
+    /** State code (e.g. CA, NY) -> rate percent. Empty or missing state uses defaultRate. */
+    private Map<String, Double> ratesByState = new HashMap<>();
+
+    public double getRateForState(String stateCode) {
+        if (stateCode == null || stateCode.isBlank()) return defaultRate;
+        String key = stateCode.trim().toUpperCase();
+        return ratesByState.getOrDefault(key, defaultRate);
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/AdminController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.accessplus.eventpro.api.controller;
 
 import com.accessplus.eventpro.api.dto.*;
 import com.accessplus.eventpro.api.service.AdminService;
+import com.accessplus.eventpro.api.service.AuthService;
 import com.accessplus.eventpro.api.service.VerificationService;
 import com.accessplus.eventpro.api.subscription.entity.SubscriptionPaymentEntity;
 import com.accessplus.eventpro.api.subscription.service.SubscriptionPaymentService;
@@ -37,6 +38,7 @@ import java.util.UUID;
 public class AdminController extends BaseController {
 
     private final AdminService adminService;
+    private final AuthService authService;
     private final UserService userService;
     private final EventService eventService;
     private final EventRepository eventRepository;
@@ -136,6 +138,17 @@ public class AdminController extends BaseController {
         EventResponse response = EventResponse.fromEntity(event);
 
         return ResponseEntity.ok(ApiResponse.success(response, "Event status updated successfully"));
+    }
+
+    @PostMapping("/users")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Create admin user", description = "Creates a new user with ADMIN role. Requires ADMIN role.")
+    public ResponseEntity<ApiResponse<UserResponse>> createAdminUser(
+            @Valid @RequestBody CreateAdminUserRequest request) {
+        log.debug("Creating admin user: email={}", request.getEmail());
+        UserEntity user = authService.createAdminUser(request);
+        UserResponse response = UserResponse.fromEntity(user);
+        return ResponseEntity.ok(ApiResponse.success(response, "Admin user created successfully"));
     }
 
     @GetMapping("/users")

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/AdminController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/AdminController.java
@@ -2,6 +2,9 @@ package com.accessplus.eventpro.api.controller;
 
 import com.accessplus.eventpro.api.dto.*;
 import com.accessplus.eventpro.api.service.AdminService;
+import com.accessplus.eventpro.api.service.VerificationService;
+import com.accessplus.eventpro.api.subscription.entity.SubscriptionPaymentEntity;
+import com.accessplus.eventpro.api.subscription.service.SubscriptionPaymentService;
 import com.accessplus.eventpro.core.user.entity.UserEntity;
 import com.accessplus.eventpro.core.user.service.UserService;
 import com.accessplus.eventpro.event.event.entity.EventEntity;
@@ -37,6 +40,36 @@ public class AdminController extends BaseController {
     private final UserService userService;
     private final EventService eventService;
     private final EventRepository eventRepository;
+    private final SubscriptionPaymentService subscriptionPaymentService;
+    private final VerificationService verificationService;
+
+    @GetMapping("/verification-pending")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List pending KYC submissions", description = "Returns PENDING identity verification submissions for admin review. Requires ADMIN role.")
+    public ResponseEntity<ApiResponse<List<PendingVerificationResponse>>> listPendingVerifications(
+            @RequestParam(defaultValue = "50") int limit) {
+        List<PendingVerificationResponse> list = verificationService.listPendingSubmissions(limit);
+        return ResponseEntity.ok(ApiResponse.success(list));
+    }
+
+    @PostMapping("/verification/{submissionId}/approve")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Approve KYC submission", description = "Marks submission as VERIFIED and sets user as verified. Requires ADMIN role.")
+    public ResponseEntity<ApiResponse<String>> approveVerification(@PathVariable UUID submissionId) {
+        verificationService.approveSubmission(submissionId);
+        return ResponseEntity.ok(ApiResponse.success("Verification approved.", "Approved"));
+    }
+
+    @PostMapping("/verification/{submissionId}/reject")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Reject KYC submission", description = "Marks submission as REJECTED and sets user verification status. Optional reason in body. Requires ADMIN role.")
+    public ResponseEntity<ApiResponse<String>> rejectVerification(
+            @PathVariable UUID submissionId,
+            @RequestBody(required = false) java.util.Map<String, String> body) {
+        String reason = body != null && body.containsKey("reason") ? body.get("reason") : null;
+        verificationService.rejectSubmission(submissionId, reason);
+        return ResponseEntity.ok(ApiResponse.success("Verification rejected.", "Rejected"));
+    }
 
     @GetMapping("/stats")
     @PreAuthorize("hasRole('ADMIN')")
@@ -178,5 +211,16 @@ public class AdminController extends BaseController {
         
         UserResponse response = UserResponse.fromEntity(updatedUser);
         return ResponseEntity.ok(ApiResponse.success(response, "User role updated successfully"));
+    }
+
+    @PostMapping("/subscription-payments")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Record subscription payment", description = "Records a Pro/Enterprise subscription payment for an organizer. Used for 1099-K 'subscription fees paid' and billing. Requires ADMIN role.")
+    public ResponseEntity<ApiResponse<SubscriptionPaymentEntity>> recordSubscriptionPayment(
+            @Valid @RequestBody RecordSubscriptionPaymentRequest request) {
+        log.debug("Recording subscription payment: userId={}, amount={}, tier={}", request.getUserId(), request.getAmount(), request.getTier());
+        SubscriptionPaymentEntity payment = subscriptionPaymentService.recordPayment(
+                request.getUserId(), request.getAmount(), request.getTier(), request.getPeriod());
+        return ResponseEntity.ok(ApiResponse.success(payment, "Subscription payment recorded"));
     }
 }

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/OrganizerController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/OrganizerController.java
@@ -1,7 +1,11 @@
 package com.accessplus.eventpro.api.controller;
 
 import com.accessplus.eventpro.api.dto.*;
+import com.accessplus.eventpro.api.payout.dto.PayoutRequestResponse;
+import com.accessplus.eventpro.api.payout.dto.RequestPayoutRequest;
+import com.accessplus.eventpro.api.payout.service.PayoutRequestService;
 import com.accessplus.eventpro.api.service.OrganizerService;
+import com.accessplus.eventpro.api.service.TaxFormPdfService;
 import com.accessplus.eventpro.api.team.service.OrganizerTeamService;
 import com.accessplus.eventpro.api.service.RiskScoringService;
 import com.accessplus.eventpro.api.service.VerificationService;
@@ -69,6 +73,8 @@ public class OrganizerController extends BaseController {
     private final ObjectMapper objectMapper;
     private final UserRepository userRepository;
     private final OrganizerTeamService organizerTeamService;
+    private final TaxFormPdfService taxFormPdfService;
+    private final PayoutRequestService payoutRequestService;
 
     /** Merchandise & add-ons require Pro or Enterprise per pricing page. */
     private void requireAddonsEligible() {
@@ -166,6 +172,24 @@ public class OrganizerController extends BaseController {
         return ResponseEntity.ok(ApiResponse.success(summary));
     }
 
+    @PostMapping("/payouts/request")
+    @PreAuthorize("hasAnyRole('ORGANIZER', 'ADMIN')")
+    @Operation(summary = "Request payout", description = "Submit a payout request for the given amount. Validates available balance and eligibility (verified, W-9 if $600+). Actual transfer is processed separately.")
+    public ResponseEntity<ApiResponse<PayoutRequestResponse>> requestPayout(@Valid @RequestBody RequestPayoutRequest request) {
+        UUID organizerId = JwtUtils.getCurrentUserId();
+        PayoutRequestResponse response = payoutRequestService.requestPayout(organizerId, request);
+        return ResponseEntity.ok(ApiResponse.success(response, "Payout requested. You will be notified when it is processed."));
+    }
+
+    @GetMapping("/payouts")
+    @PreAuthorize("hasAnyRole('ORGANIZER', 'ADMIN')")
+    @Operation(summary = "List payout requests", description = "Returns the organizer's payout requests (pending and completed).")
+    public ResponseEntity<ApiResponse<Page<PayoutRequestResponse>>> getPayoutRequests(Pageable pageable) {
+        UUID organizerId = JwtUtils.getCurrentUserId();
+        Page<PayoutRequestResponse> page = payoutRequestService.getPayoutRequests(organizerId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(page));
+    }
+
     @GetMapping("/verification-status")
     @PreAuthorize("hasAnyRole('ORGANIZER', 'ADMIN')")
     @Operation(summary = "Get verification status", description = "Returns KYC verification status and risk level for Profile badge and payout gate.")
@@ -195,19 +219,69 @@ public class OrganizerController extends BaseController {
 
     @GetMapping("/tax-forms")
     @PreAuthorize("hasAnyRole('ORGANIZER', 'ADMIN')")
-    @Operation(summary = "List tax forms (1099-K)", description = "Returns list of tax forms by year for Document Vault.")
+    @Operation(summary = "List tax forms (1099-K)", description = "Returns list of tax forms by year for Document Vault. Enterprise only per pricing. 1099-K for a year is available after IRS deadline (Jan 31 of following year).")
     public ResponseEntity<ApiResponse<List<TaxFormResponse>>> getTaxForms() {
         UUID organizerId = JwtUtils.getCurrentUserId();
+        UserEntity user = userRepository.findById(organizerId).orElseThrow(() -> new ResourceNotFoundException("User", organizerId.toString()));
+        if (!"ENTERPRISE".equalsIgnoreCase(user.getSubscriptionTier())) {
+            return ResponseEntity.ok(ApiResponse.success(java.util.Collections.emptyList()));
+        }
         int currentYear = java.time.Year.now().getValue();
-        List<TaxFormResponse> forms = List.of(
-                TaxFormResponse.builder()
-                        .year(String.valueOf(currentYear))
-                        .formType("1099-K")
-                        .status("Available")
-                        .downloadUrl(null)
-                        .build()
-        );
+        java.time.LocalDate now = java.time.LocalDate.now();
+        // IRS: 1099-K for year Y is due to recipient by Jan 31 of year Y+1. So e.g. 2025 form is "Available" from Feb 1, 2026.
+        java.time.LocalDate deadlinePriorYear = java.time.LocalDate.of(currentYear, 1, 31);
+        java.util.List<TaxFormResponse> forms = new java.util.ArrayList<>();
+        if (now.isAfter(deadlinePriorYear)) {
+            forms.add(TaxFormResponse.builder()
+                    .year(String.valueOf(currentYear - 1))
+                    .formType("1099-K")
+                    .status("Available")
+                    .downloadUrl("/api/v1/organizer/tax-forms/" + (currentYear - 1) + "/download")
+                    .build());
+        }
+        // Current year form: show as pending until next year's deadline
+        forms.add(TaxFormResponse.builder()
+                .year(String.valueOf(currentYear))
+                .formType("1099-K")
+                .status("Available after Jan 31, " + (currentYear + 1))
+                .downloadUrl(null)
+                .build());
         return ResponseEntity.ok(ApiResponse.success(forms));
+    }
+
+    @GetMapping("/tax-forms/{year}/download")
+    @PreAuthorize("hasAnyRole('ORGANIZER', 'ADMIN')")
+    @Operation(summary = "Download 1099-K PDF", description = "Generates and returns 1099-K PDF for the given tax year. Enterprise only. Available only for years past IRS deadline (Jan 31 of following year).")
+    public ResponseEntity<byte[]> downloadTaxFormPdf(@PathVariable int year) {
+        UUID organizerId = JwtUtils.getCurrentUserId();
+        UserEntity user = userRepository.findById(organizerId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", organizerId.toString()));
+        if (!"ENTERPRISE".equalsIgnoreCase(user.getSubscriptionTier())) {
+            throw new AccessDeniedException("1099-K reports are available on the Enterprise plan.");
+        }
+        int currentYear = java.time.Year.now().getValue();
+        java.time.LocalDate now = java.time.LocalDate.now();
+        java.time.LocalDate deadline = java.time.LocalDate.of(year + 1, 1, 31);
+        if (year >= currentYear || !now.isAfter(deadline)) {
+            throw new ValidationException("1099-K for " + year + " is not available for download until after Jan 31, " + (year + 1));
+        }
+        java.math.BigDecimal grossAmount = organizerService.getOrganizerRevenueForYear(organizerId, year);
+        java.math.BigDecimal feesWithheld = organizerService.getOrganizerFeesForYear(organizerId, year);
+        java.math.BigDecimal subscriptionPaymentsForYear = organizerService.getOrganizerSubscriptionPaymentsForYear(organizerId, year);
+        String recipientName = (user.getFirstName() != null ? user.getFirstName() + " " : "") + (user.getLastName() != null ? user.getLastName() : "").trim();
+        if (recipientName.isBlank()) recipientName = user.getEmail();
+        if (recipientName == null) recipientName = "—";
+        try {
+            byte[] pdfBytes = taxFormPdfService.generate1099KPdf(recipientName, user.getEmail(), year, grossAmount, feesWithheld, subscriptionPaymentsForYear);
+            org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+            headers.setContentType(org.springframework.http.MediaType.APPLICATION_PDF);
+            headers.setContentDispositionFormData("attachment", "1099-K-" + year + ".pdf");
+            headers.setContentLength(pdfBytes.length);
+            return ResponseEntity.ok().headers(headers).body(pdfBytes);
+        } catch (java.io.IOException e) {
+            log.error("Failed to generate 1099-K PDF: year={}, error={}", year, e.getMessage(), e);
+            throw new ValidationException("Failed to generate PDF: " + e.getMessage());
+        }
     }
 
     @PostMapping("/w9")

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/PaymentController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.accessplus.eventpro.api.controller;
 
 import com.accessplus.eventpro.api.dto.ApiResponse;
+import com.accessplus.eventpro.api.dto.CheckoutTotalsResponse;
 import com.accessplus.eventpro.api.dto.ConfirmPaymentRequest;
 import com.accessplus.eventpro.api.dto.CreatePaymentIntentRequest;
 import com.accessplus.eventpro.api.dto.GuestConfirmPaymentRequest;
@@ -11,6 +12,8 @@ import com.accessplus.eventpro.core.notification.service.NotificationService;
 import com.accessplus.eventpro.core.security.JwtUtils;
 import com.accessplus.eventpro.core.user.service.UserService;
 import com.accessplus.eventpro.event.event.service.EventService;
+import com.accessplus.eventpro.api.config.TaxProperties;
+import com.accessplus.eventpro.order.cart.service.CartService;
 import com.accessplus.eventpro.order.order.model.GuestOrderItem;
 import com.accessplus.eventpro.order.order.service.OrderService;
 import com.accessplus.eventpro.payment.service.PaymentService;
@@ -25,8 +28,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -47,11 +54,54 @@ public class PaymentController extends BaseController {
     @Value("${stripe.publishableKey:}")
     private String stripePublishableKey;
 
+    private final TaxProperties taxProperties;
+
     private final PaymentService paymentService;
     private final OrderService orderService;
+    private final CartService cartService;
     private final NotificationService notificationService;
     private final EventService eventService;
     private final UserService userService;
+
+    @GetMapping("/checkout-totals")
+    @Operation(summary = "Checkout totals with tax", description = "Returns subtotal, tax rate, tax amount, and total. Pass state (e.g. CA) and country (e.g. US) for jurisdiction-based tax; otherwise uses default rate. Use total for create-intent when tax > 0.")
+    public ResponseEntity<ApiResponse<CheckoutTotalsResponse>> getCheckoutTotals(
+            @RequestParam(required = false) BigDecimal subtotal,
+            @RequestParam(required = false) String state,
+            @RequestParam(required = false) String country) {
+        BigDecimal sub = subtotal;
+        if (sub == null || sub.compareTo(BigDecimal.ZERO) < 0) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.isAuthenticated() && auth.getPrincipal() != null && !(auth.getPrincipal() instanceof String)) {
+                try {
+                    UUID userId = JwtUtils.getCurrentUserId();
+                    sub = cartService.calculateCartTotal(userId);
+                    if (sub == null) sub = BigDecimal.ZERO;
+                } catch (Exception e) {
+                    sub = BigDecimal.ZERO;
+                }
+            }
+        }
+        if (sub == null || sub.compareTo(BigDecimal.ZERO) < 0) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("Subtotal required when not authenticated. Pass ?subtotal= amount or log in."));
+        }
+        // Jurisdiction-based rate: use buyer state when country is US (or omitted); else default rate
+        boolean useStateRate = country == null || country.isBlank() || "US".equalsIgnoreCase(country.trim());
+        double ratePercent = useStateRate ? taxProperties.getRateForState(state) : taxProperties.getDefaultRate();
+        BigDecimal tax = BigDecimal.ZERO;
+        if (ratePercent > 0) {
+            tax = sub.multiply(BigDecimal.valueOf(ratePercent)).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+        }
+        BigDecimal total = sub.add(tax);
+        CheckoutTotalsResponse body = CheckoutTotalsResponse.builder()
+                .subtotal(sub)
+                .taxRatePercent(ratePercent)
+                .tax(tax)
+                .total(total)
+                .build();
+        return ResponseEntity.ok(ApiResponse.success(body, null));
+    }
 
     @GetMapping("/config")
     @Operation(summary = "Payment config (public)", description = "Returns Stripe publishable key for the frontend card form. No auth required.")
@@ -93,14 +143,27 @@ public class PaymentController extends BaseController {
     @PostMapping("/confirm")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN', 'ORGANIZER')")
     @SecurityRequirement(name = "bearerAuth")
-    @Operation(summary = "Confirm payment (authenticated)", description = "Confirms a Stripe payment and creates an order from the user's cart.")
+    @Operation(summary = "Confirm payment (authenticated)", description = "Confirms a Stripe payment and creates an order from the user's cart. Optional state/country for jurisdiction-based sales tax.")
     public ResponseEntity<ApiResponse<OrderResponse>> confirmPayment(
             @Valid @RequestBody ConfirmPaymentRequest request) {
         log.debug("Confirming payment: paymentIntentId={}", request.getPaymentIntentId());
 
         try {
             UUID userId = JwtUtils.getCurrentUserId();
-            var order = paymentService.processPayment(userId, request.getPaymentIntentId());
+            String state = request.getState() != null && !request.getState().isBlank() ? request.getState().trim() : null;
+            String country = request.getCountry() != null && !request.getCountry().isBlank() ? request.getCountry().trim() : null;
+            BigDecimal taxAmount = null;
+            if (state != null || country != null) {
+                BigDecimal cartTotal = cartService.calculateCartTotal(userId);
+                if (cartTotal != null && cartTotal.compareTo(BigDecimal.ZERO) > 0) {
+                    boolean useStateRate = country == null || "US".equalsIgnoreCase(country);
+                    double rate = useStateRate ? taxProperties.getRateForState(state) : taxProperties.getDefaultRate();
+                    if (rate > 0) {
+                        taxAmount = cartTotal.multiply(BigDecimal.valueOf(rate)).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+                    }
+                }
+            }
+            var order = paymentService.processPayment(userId, request.getPaymentIntentId(), taxAmount, state, country);
             OrderResponse response = OrderResponse.fromEntity(order);
 
             sendOrderConfirmationNotification(order, userId, null);
@@ -145,6 +208,8 @@ public class PaymentController extends BaseController {
             List<GuestOrderItem> items = request.getItems().stream()
                     .map(i -> new GuestOrderItem(i.getEventId(), i.getTicketType(), i.getQuantity()))
                     .collect(Collectors.toList());
+            String state = request.getState() != null && !request.getState().isBlank() ? request.getState().trim() : null;
+            String country = request.getCountry() != null && !request.getCountry().isBlank() ? request.getCountry().trim() : null;
             var order = paymentService.processGuestPayment(
                     request.getPaymentIntentId(),
                     request.getEmail(),
@@ -153,7 +218,10 @@ public class PaymentController extends BaseController {
                     items,
                     request.getTotalAmount(),
                     request.getReservedTicketIds(),
-                    request.getDonationAmount());
+                    request.getDonationAmount(),
+                    request.getTaxAmount(),
+                    state,
+                    country);
             OrderResponse response = OrderResponse.fromEntity(order);
 
             sendOrderConfirmationNotification(order, null, request.getEmail());

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/StripeWebhookController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/StripeWebhookController.java
@@ -1,0 +1,217 @@
+package com.accessplus.eventpro.api.controller;
+
+import com.accessplus.eventpro.api.config.StripeSubscriptionConfig;
+import com.accessplus.eventpro.core.notification.service.NotificationService;
+import com.accessplus.eventpro.core.user.entity.UserEntity;
+import com.accessplus.eventpro.core.user.service.UserService;
+import com.accessplus.eventpro.api.subscription.service.SubscriptionPaymentService;
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.model.Event;
+import com.stripe.model.Invoice;
+import com.stripe.model.Subscription;
+import com.stripe.net.Webhook;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Handles Stripe webhooks (subscription lifecycle). No auth - verified by Stripe signature.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/webhooks")
+@RequiredArgsConstructor
+public class StripeWebhookController {
+
+    @Value("${stripe.webhookSecret:}")
+    private String webhookSecret;
+
+    private final UserService userService;
+    private final SubscriptionPaymentService subscriptionPaymentService;
+    private final StripeSubscriptionConfig subscriptionConfig;
+    private final NotificationService notificationService;
+
+    @PostMapping("/stripe")
+    public ResponseEntity<Map<String, Object>> handleStripeWebhook(
+            @RequestBody String payload,
+            @RequestHeader(value = "Stripe-Signature", required = false) String stripeSignature) {
+        if (stripeSignature == null || stripeSignature.isBlank() || webhookSecret == null || webhookSecret.isBlank()) {
+            log.warn("Stripe webhook called without signature or secret not set");
+            return ResponseEntity.status(400).body(Map.of("error", "Missing signature or webhook secret not configured"));
+        }
+        Event event;
+        try {
+            event = Webhook.constructEvent(payload, stripeSignature, webhookSecret);
+        } catch (SignatureVerificationException e) {
+            log.warn("Stripe webhook signature verification failed: {}", e.getMessage());
+            return ResponseEntity.status(400).body(Map.of("error", "Invalid signature"));
+        }
+
+        String type = event.getType();
+        log.debug("Stripe webhook: type={}", type);
+
+        try {
+            switch (type) {
+                case "invoice.paid" -> handleInvoicePaid(event);
+                case "customer.subscription.deleted" -> handleSubscriptionDeleted(event);
+                case "customer.subscription.updated" -> handleSubscriptionUpdated(event);
+                default -> log.trace("Unhandled Stripe event type: {}", type);
+            }
+        } catch (Exception e) {
+            log.error("Error processing Stripe webhook {}: {}", type, e.getMessage(), e);
+            return ResponseEntity.status(500).body(Map.of("error", "Processing failed"));
+        }
+
+        return ResponseEntity.ok(Map.of("received", true));
+    }
+
+    private void handleInvoicePaid(Event event) {
+        Invoice invoice;
+        try {
+            Optional<?> opt = event.getDataObjectDeserializer().getObject();
+            if (opt.isEmpty()) {
+                log.warn("invoice.paid: could not deserialize event data");
+                return;
+            }
+            Object obj = opt.get();
+            if (!(obj instanceof Invoice)) {
+                log.warn("invoice.paid event data is not an Invoice");
+                return;
+            }
+            invoice = (Invoice) obj;
+        } catch (Exception e) {
+            log.warn("Failed to deserialize invoice: {}", e.getMessage());
+            return;
+        }
+
+        String subscriptionId = invoice.getSubscription();
+        if (subscriptionId == null || subscriptionId.isBlank()) {
+            log.debug("invoice.paid has no subscription (one-time payment), skipping");
+            return;
+        }
+
+        String customerId = invoice.getCustomer();
+        if (customerId == null || customerId.isBlank()) {
+            log.warn("invoice.paid has no customer");
+            return;
+        }
+
+        UserEntity user;
+        try {
+            user = userService.getUserByStripeCustomerId(customerId);
+        } catch (Exception e) {
+            log.warn("No user found for Stripe customer {}: {}", customerId, e.getMessage());
+            return;
+        }
+
+        String tier = "PRO";
+        String period = "MONTHLY";
+        try {
+            Subscription subscription = Subscription.retrieve(subscriptionId);
+            if (subscription.getItems() != null && subscription.getItems().getData() != null && !subscription.getItems().getData().isEmpty()) {
+                var item = subscription.getItems().getData().get(0);
+                if (item.getPrice() != null && item.getPrice().getId() != null) {
+                    String priceId = item.getPrice().getId();
+                    tier = tierFromPriceId(priceId);
+                    period = periodFromPriceId(priceId);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Could not get subscription for tier/period, using defaults: {}", e.getMessage());
+        }
+
+        long amountPaid = invoice.getAmountPaid() != null ? invoice.getAmountPaid() : 0;
+        BigDecimal amount = BigDecimal.valueOf(amountPaid).divide(BigDecimal.valueOf(100)); // cents to dollars
+        Instant paidAt = invoice.getStatusTransitions() != null && invoice.getStatusTransitions().getPaidAt() != null
+                ? Instant.ofEpochSecond(invoice.getStatusTransitions().getPaidAt())
+                : Instant.now();
+
+        subscriptionPaymentService.recordPayment(user.getId(), amount, tier, period, paidAt);
+        userService.setSubscriptionTierAndOrganizerRole(user.getId(), tier);
+        log.info("Processed invoice.paid: userId={}, tier={}, amount={}", user.getId(), tier, amount);
+    }
+
+    private void handleSubscriptionDeleted(Event event) {
+        Object obj;
+        try {
+            Optional<?> opt = event.getDataObjectDeserializer().getObject();
+            if (opt.isEmpty()) return;
+            obj = opt.get();
+        } catch (Exception e) {
+            log.warn("Failed to deserialize subscription: {}", e.getMessage());
+            return;
+        }
+        if (!(obj instanceof Subscription)) return;
+        Subscription subscription = (Subscription) obj;
+        String customerId = subscription.getCustomer();
+        if (customerId == null || customerId.isBlank()) return;
+        try {
+            UserEntity user = userService.getUserByStripeCustomerId(customerId);
+            userService.setSubscriptionTier(user.getId(), "BASIC");
+            log.info("Subscription cancelled: userId={}, set tier to BASIC", user.getId());
+        } catch (Exception e) {
+            log.warn("No user for Stripe customer {} on subscription.deleted: {}", customerId, e.getMessage());
+        }
+    }
+
+    private void handleSubscriptionUpdated(Event event) {
+        Object obj;
+        try {
+            Optional<?> opt = event.getDataObjectDeserializer().getObject();
+            if (opt.isEmpty()) return;
+            obj = opt.get();
+        } catch (Exception e) {
+            log.warn("Failed to deserialize subscription: {}", e.getMessage());
+            return;
+        }
+        if (!(obj instanceof Subscription)) return;
+        Subscription subscription = (Subscription) obj;
+        // active = paying; trialing = 14-day trial (no payment yet) – grant Pro/Enterprise in both cases
+        String status = subscription.getStatus();
+        if (status == null || (!"active".equals(status) && !"trialing".equals(status))) return;
+        String customerId = subscription.getCustomer();
+        if (customerId == null || customerId.isBlank()) return;
+        try {
+            UserEntity user = userService.getUserByStripeCustomerId(customerId);
+            String tier = "PRO";
+            if (subscription.getItems() != null && subscription.getItems().getData() != null && !subscription.getItems().getData().isEmpty()) {
+                var item = subscription.getItems().getData().get(0);
+                if (item.getPrice() != null && item.getPrice().getId() != null) {
+                    tier = tierFromPriceId(item.getPrice().getId());
+                }
+            }
+            userService.setSubscriptionTierAndOrganizerRole(user.getId(), tier);
+            log.info("Subscription updated: userId={}, tier={}", user.getId(), tier);
+            String first = user.getFirstName() != null ? user.getFirstName().trim() : "";
+            String last = user.getLastName() != null ? user.getLastName().trim() : "";
+            String name = (first + " " + last).trim();
+            if (name.isBlank() && user.getEmail() != null) name = user.getEmail();
+            notificationService.sendSubscriptionUpgradedEmail(user.getEmail(), name, tier);
+        } catch (Exception e) {
+            log.warn("Could not update user for subscription.updated: {}", e.getMessage());
+        }
+    }
+
+    private String tierFromPriceId(String priceId) {
+        if (priceId == null) return "PRO";
+        if (priceId.equals(subscriptionConfig.getPriceIdEnterpriseMonthly()) || priceId.equals(subscriptionConfig.getPriceIdEnterpriseYearly())) {
+            return "ENTERPRISE";
+        }
+        return "PRO";
+    }
+
+    private String periodFromPriceId(String priceId) {
+        if (priceId == null) return "MONTHLY";
+        if (priceId.equals(subscriptionConfig.getPriceIdProYearly()) || priceId.equals(subscriptionConfig.getPriceIdEnterpriseYearly())) {
+            return "YEARLY";
+        }
+        return "MONTHLY";
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/SubscriptionController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/SubscriptionController.java
@@ -1,0 +1,132 @@
+package com.accessplus.eventpro.api.controller;
+
+import com.accessplus.eventpro.api.config.StripeSubscriptionConfig;
+import com.accessplus.eventpro.api.dto.ApiResponse;
+import com.accessplus.eventpro.api.dto.CreateSubscriptionCheckoutRequest;
+import com.accessplus.eventpro.api.dto.UserResponse;
+import com.accessplus.eventpro.core.security.JwtUtils;
+import com.accessplus.eventpro.core.user.entity.UserEntity;
+import com.accessplus.eventpro.core.user.service.UserService;
+import com.accessplus.eventpro.payment.stripe.service.StripeService;
+import com.accessplus.eventpro.shared.exception.ValidationException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Subscription;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/subscription")
+@RequiredArgsConstructor
+@Tag(name = "Subscription", description = "Pro/Enterprise subscription checkout")
+@SecurityRequirement(name = "bearerAuth")
+public class SubscriptionController extends BaseController {
+
+    private final UserService userService;
+    private final StripeService stripeService;
+    private final StripeSubscriptionConfig subscriptionConfig;
+
+    @PostMapping("/create-checkout-session")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Create subscription checkout session",
+            description = "Creates a Stripe Checkout Session for Pro/Enterprise. Redirect the user to the returned URL. After payment, Stripe webhooks will update the user's tier and record the payment.")
+    public ResponseEntity<ApiResponse<Map<String, String>>> createCheckoutSession(
+            @Valid @RequestBody CreateSubscriptionCheckoutRequest request) {
+        UUID userId = JwtUtils.getCurrentUserId();
+        UserEntity user = userService.getUserById(userId);
+
+        String priceId = subscriptionConfig.getPriceId(request.getTier(), request.getPeriod());
+        if (priceId == null || priceId.isBlank()) {
+            throw new ValidationException(
+                    "Subscription pricing is not configured. Set STRIPE_PRICE_PRO_MONTHLY (and other price IDs) in your environment.");
+        }
+
+        try {
+            String customerId = user.getStripeCustomerId();
+            if (customerId == null || customerId.isBlank()) {
+                String name = (user.getFirstName() != null ? user.getFirstName() : "") + " " + (user.getLastName() != null ? user.getLastName() : "").trim();
+                customerId = stripeService.createCustomer(user.getEmail(), name.isEmpty() ? null : name);
+                userService.updateStripeCustomerId(userId, customerId);
+            }
+
+            String period = (request.getPeriod() != null && !request.getPeriod().isBlank()) ? request.getPeriod().trim().toUpperCase() : "MONTHLY";
+            String url = stripeService.createSubscriptionCheckoutSession(
+                    customerId,
+                    priceId,
+                    request.getSuccessUrl(),
+                    request.getCancelUrl(),
+                    userId.toString());
+
+            if (url == null || url.isBlank()) {
+                throw new ValidationException("Failed to create checkout session");
+            }
+            return ResponseEntity.ok(ApiResponse.success(Map.of("url", url)));
+        } catch (StripeException e) {
+            log.warn("Stripe error creating checkout session: {}", e.getMessage());
+            throw new ValidationException("Payment provider error: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/sync")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Sync subscription from Stripe",
+            description = "Fetches the current user's active Stripe subscription and updates their tier and role (e.g. PRO + ORGANIZER). Use after payment if webhooks were not received, or to fix an already-upgraded user.")
+    public ResponseEntity<ApiResponse<UserResponse>> syncSubscriptionFromStripe() {
+        UUID userId = JwtUtils.getCurrentUserId();
+        UserEntity user = userService.getUserById(userId);
+        String customerId = user.getStripeCustomerId();
+        if (customerId == null || customerId.isBlank()) {
+            return ResponseEntity.ok(ApiResponse.success(
+                    UserResponse.fromEntity(user),
+                    "No Stripe customer linked. Tier unchanged."));
+        }
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("customer", customerId);
+            params.put("limit", 1);
+            // Check active first (paying), then trialing (14-day trial – no payment yet)
+            params.put("status", "active");
+            List<Subscription> subs = Subscription.list(params).getData();
+            if (subs == null || subs.isEmpty()) {
+                params.put("status", "trialing");
+                subs = Subscription.list(params).getData();
+            }
+            if (subs == null || subs.isEmpty()) {
+                userService.setSubscriptionTier(userId, "BASIC");
+                user = userService.getUserById(userId);
+                return ResponseEntity.ok(ApiResponse.success(
+                        UserResponse.fromEntity(user),
+                        "No active subscription. Set to BASIC."));
+            }
+            Subscription sub = subs.get(0);
+            String priceId = null;
+            if (sub.getItems() != null && sub.getItems().getData() != null && !sub.getItems().getData().isEmpty()) {
+                var item = sub.getItems().getData().get(0);
+                if (item.getPrice() != null && item.getPrice().getId() != null) {
+                    priceId = item.getPrice().getId();
+                }
+            }
+            String tier = subscriptionConfig.getTierFromPriceId(priceId);
+            userService.setSubscriptionTierAndOrganizerRole(userId, tier);
+            user = userService.getUserById(userId);
+            return ResponseEntity.ok(ApiResponse.success(
+                    UserResponse.fromEntity(user),
+                    "Synced from Stripe: tier=" + tier + ", role updated."));
+        } catch (StripeException e) {
+            log.warn("Stripe error syncing subscription: {}", e.getMessage());
+            throw new ValidationException("Could not sync subscription: " + e.getMessage());
+        }
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/UserController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/UserController.java
@@ -74,6 +74,13 @@ public class UserController extends BaseController {
         log.debug("Updating current user profile");
 
         UUID userId = JwtUtils.getCurrentUserId();
+        UserEntity currentUser = userService.getUserById(userId);
+        String tier = currentUser.getSubscriptionTier() != null ? currentUser.getSubscriptionTier().toUpperCase() : "BASIC";
+        // White-label branding (logo, primary color, hide platform) is Enterprise only per pricing page
+        String brandingLogoUrl = "ENTERPRISE".equals(tier) ? request.getBrandingLogoUrl() : null;
+        String brandingPrimaryColor = "ENTERPRISE".equals(tier) ? request.getBrandingPrimaryColor() : null;
+        Boolean brandingHidePlatform = "ENTERPRISE".equals(tier) ? request.getBrandingHidePlatform() : null;
+
         UserEntity updatedUser = userService.updateUserProfile(
                 userId,
                 request.getFirstName(),
@@ -83,9 +90,9 @@ public class UserController extends BaseController {
                 request.getLocation(),
                 null, // profilePictureUrl is updated via separate endpoint
                 request.getCulturalNiche(),
-                request.getBrandingLogoUrl(),
-                request.getBrandingPrimaryColor(),
-                request.getBrandingHidePlatform()
+                brandingLogoUrl,
+                brandingPrimaryColor,
+                brandingHidePlatform
         );
         UserResponse response = UserResponse.fromEntity(updatedUser);
 

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/CheckoutTotalsResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/CheckoutTotalsResponse.java
@@ -1,0 +1,20 @@
+package com.accessplus.eventpro.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/** Subtotal, tax, and total for checkout. Use total for payment intent when tax is enabled. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckoutTotalsResponse {
+    private BigDecimal subtotal;
+    private double taxRatePercent;
+    private BigDecimal tax;
+    private BigDecimal total;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/ConfirmPaymentRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/ConfirmPaymentRequest.java
@@ -11,8 +11,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ConfirmPaymentRequest {
-    
+
     @NotBlank(message = "Payment intent ID is required")
     private String paymentIntentId;
+
+    /** Buyer state (e.g. CA, NY) for jurisdiction-based sales tax. Optional. */
+    private String state;
+
+    /** Buyer country (e.g. US) for tax jurisdiction. Optional. */
+    private String country;
 }
 

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/CreateAdminUserRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/CreateAdminUserRequest.java
@@ -1,0 +1,30 @@
+package com.accessplus.eventpro.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Request body for creating a new user with ADMIN role.
+ * Only existing admins can call this endpoint.
+ */
+@Data
+public class CreateAdminUserRequest {
+
+    @Email(message = "Must be a valid email")
+    @NotBlank(message = "Email is required")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+
+    @NotBlank(message = "First name is required")
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    private String lastName;
+
+    private String phoneNumber;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/CreateSubscriptionCheckoutRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/CreateSubscriptionCheckoutRequest.java
@@ -1,0 +1,26 @@
+package com.accessplus.eventpro.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateSubscriptionCheckoutRequest {
+
+    @NotBlank(message = "Tier is required")
+    @Pattern(regexp = "^(?i)(PRO|ENTERPRISE)$", message = "Tier must be PRO or ENTERPRISE")
+    private String tier;
+
+    @Pattern(regexp = "^(?i)(MONTHLY|YEARLY)$", message = "Period must be MONTHLY or YEARLY")
+    private String period = "MONTHLY";
+
+    @NotBlank(message = "Success URL is required")
+    private String successUrl;
+
+    @NotBlank(message = "Cancel URL is required")
+    private String cancelUrl;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/GuestConfirmPaymentRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/GuestConfirmPaymentRequest.java
@@ -52,4 +52,13 @@ public class GuestConfirmPaymentRequest {
 
     /** Optional: send ticket via SMS when true. */
     private Boolean receiveTicketViaSMS;
+
+    /** Optional: buyer state (e.g. CA, NY) for sales tax jurisdiction. */
+    private String state;
+
+    /** Optional: buyer country (e.g. US). */
+    private String country;
+
+    /** Optional: tax amount when state/country was used at checkout (so order stores it). */
+    private BigDecimal taxAmount;
 }

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/OrderResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/OrderResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,7 @@ public class OrderResponse {
     private UUID id;
     private UUID userId;
     private Long amount; // Order total amount in cents (for legacy API compatibility)
+    private BigDecimal taxAmount; // Sales tax / VAT amount for this order (0 when not applied)
     private String status; // PENDING, COMPLETED, CANCELLED, REFUNDED
     private LocalDateTime orderDate;
     private List<OrderItemResponse> orderItems;
@@ -52,6 +54,7 @@ public class OrderResponse {
                 .id(entity.getId())
                 .userId(entity.getUserId())
                 .amount(amountInCents)
+                .taxAmount(entity.getTaxAmount() != null ? entity.getTaxAmount() : BigDecimal.ZERO)
                 .status(statusStr)
                 .orderDate(entity.getOrderDate())
                 .orderItems(orderItemResponses)

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/OrganizerSummaryResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/OrganizerSummaryResponse.java
@@ -21,12 +21,18 @@ public class OrganizerSummaryResponse {
     private long ticketsSold;
     /** Percent change in tickets sold this week vs last week; null if not computed. */
     private Integer ticketsSoldTrendPercent;
-    /** Life-to-date total revenue from paid orders for organizer's events. */
+    /** Life-to-date total revenue from paid orders for organizer's events (gross). */
     private BigDecimal totalRevenue;
-    /** Available for payout (cleared risk scoring). */
+    /** Platform fees withheld from ticket sales (tier-based: Basic 3.5%+$0.99, Pro 2.9%+$0.79, Enterprise 2.5%+$0.49). */
+    private BigDecimal platformFeesWithheld;
+    /** Fee rate for current plan, e.g. "2.9% + $0.79 per ticket (Pro)". */
+    private String platformFeeRateLabel;
+    /** Available for payout (gross revenue minus platform fees). */
     private BigDecimal availableBalance;
-    /** Pending balance in 1–3 day holding window. */
+    /** Pending balance (net from sales in the hold window). */
     private BigDecimal pendingBalance;
+    /** Hold window in days (e.g. 3); revenue from last N days is "pending". */
+    private Integer pendingHoldDays;
     /** When true, show "Review Required" and disable payouts (risk scoring). */
     private boolean riskFlagged;
     /** Risk level: LOW, MEDIUM, HIGH (for "High Risk" warning on Profile). */

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/PendingVerificationResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/PendingVerificationResponse.java
@@ -1,0 +1,24 @@
+package com.accessplus.eventpro.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PendingVerificationResponse {
+    private UUID id;
+    private UUID userId;
+    private String email;
+    private String legalEntityType;
+    private String addressCity;
+    private String addressState;
+    private Instant submittedAt;
+    private String status;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/RecordSubscriptionPaymentRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/RecordSubscriptionPaymentRequest.java
@@ -1,0 +1,31 @@
+package com.accessplus.eventpro.api.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecordSubscriptionPaymentRequest {
+
+    @NotNull
+    private UUID userId;
+
+    @NotNull
+    @DecimalMin(value = "0", message = "Amount must be non-negative")
+    private BigDecimal amount;
+
+    /** PRO or ENTERPRISE */
+    private String tier = "PRO";
+
+    /** MONTHLY or YEARLY */
+    private String period = "MONTHLY";
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/dto/PayoutRequestResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/dto/PayoutRequestResponse.java
@@ -1,0 +1,22 @@
+package com.accessplus.eventpro.api.payout.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PayoutRequestResponse {
+    private UUID id;
+    private BigDecimal amount;
+    private String status;
+    private Instant requestedAt;
+    private Instant completedAt;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/dto/RequestPayoutRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/dto/RequestPayoutRequest.java
@@ -1,0 +1,21 @@
+package com.accessplus.eventpro.api.payout.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestPayoutRequest {
+
+    @NotNull(message = "Amount is required")
+    @DecimalMin(value = "0.01", message = "Amount must be at least 0.01")
+    private BigDecimal amount;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/entity/PayoutRequestEntity.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/entity/PayoutRequestEntity.java
@@ -1,0 +1,54 @@
+package com.accessplus.eventpro.api.payout.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payout_requests", indexes = {
+    @Index(name = "idx_payout_requests_user_id", columnList = "user_id"),
+    @Index(name = "idx_payout_requests_status", columnList = "status"),
+    @Index(name = "idx_payout_requests_requested_at", columnList = "requested_at")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PayoutRequestEntity {
+
+    @Id
+    @GeneratedValue
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    @JdbcTypeCode(SqlTypes.UUID)
+    private UUID userId;
+
+    @Column(name = "amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal amount;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status = "PENDING";
+
+    @Column(name = "requested_at", nullable = false)
+    private Instant requestedAt = Instant.now();
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt = Instant.now();
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/repository/PayoutRequestRepository.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/repository/PayoutRequestRepository.java
@@ -1,0 +1,13 @@
+package com.accessplus.eventpro.api.payout.repository;
+
+import com.accessplus.eventpro.api.payout.entity.PayoutRequestEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PayoutRequestRepository extends JpaRepository<PayoutRequestEntity, UUID> {
+
+    Page<PayoutRequestEntity> findByUserIdOrderByRequestedAtDesc(UUID userId, Pageable pageable);
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/service/PayoutRequestService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/payout/service/PayoutRequestService.java
@@ -1,0 +1,83 @@
+package com.accessplus.eventpro.api.payout.service;
+
+import com.accessplus.eventpro.api.dto.OrganizerSummaryResponse;
+import com.accessplus.eventpro.api.payout.dto.PayoutRequestResponse;
+import com.accessplus.eventpro.api.payout.dto.RequestPayoutRequest;
+import com.accessplus.eventpro.api.service.OrganizerService;
+import com.accessplus.eventpro.api.payout.entity.PayoutRequestEntity;
+import com.accessplus.eventpro.api.payout.repository.PayoutRequestRepository;
+import com.accessplus.eventpro.core.user.entity.UserEntity;
+import com.accessplus.eventpro.core.user.repository.UserRepository;
+import com.accessplus.eventpro.shared.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PayoutRequestService {
+
+    private final PayoutRequestRepository payoutRequestRepository;
+    private final OrganizerService organizerService;
+    private final UserRepository userRepository;
+
+    /**
+     * Request a payout. Validates available balance and eligibility (verified, W-9 if required).
+     * Creates a PENDING payout request; actual transfer is processed separately (e.g. Stripe Connect, manual).
+     */
+    @Transactional
+    public PayoutRequestResponse requestPayout(UUID userId, RequestPayoutRequest request) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(() -> new ValidationException("User not found"));
+        OrganizerSummaryResponse summary = organizerService.getOrganizerSummary(userId);
+
+        if (!user.getIsVerified()) {
+            throw new ValidationException("Complete Identity Check in Profile to request payouts.");
+        }
+        if (summary.getTotalRevenue() != null && summary.getTotalRevenue().compareTo(BigDecimal.valueOf(600)) >= 0
+                && !summary.isW9Submitted()) {
+            throw new ValidationException("Submit your W-9 in the Tax Center to request payouts (required at $600+ gross).");
+        }
+
+        BigDecimal available = summary.getAvailableBalance() != null ? summary.getAvailableBalance() : BigDecimal.ZERO;
+        BigDecimal amount = request.getAmount();
+        if (amount.compareTo(available) > 0) {
+            throw new ValidationException("Amount exceeds available balance (" + available + ").");
+        }
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ValidationException("Amount must be greater than 0.");
+        }
+
+        PayoutRequestEntity entity = new PayoutRequestEntity();
+        entity.setUserId(userId);
+        entity.setAmount(amount);
+        entity.setStatus("PENDING");
+        entity.setRequestedAt(java.time.Instant.now());
+        entity = payoutRequestRepository.save(entity);
+        log.info("Payout requested: userId={}, amount={}, requestId={}", userId, amount, entity.getId());
+
+        return toResponse(entity);
+    }
+
+    public Page<PayoutRequestResponse> getPayoutRequests(UUID userId, Pageable pageable) {
+        return payoutRequestRepository.findByUserIdOrderByRequestedAtDesc(userId, pageable)
+                .map(this::toResponse);
+    }
+
+    private PayoutRequestResponse toResponse(PayoutRequestEntity e) {
+        return PayoutRequestResponse.builder()
+                .id(e.getId())
+                .amount(e.getAmount())
+                .status(e.getStatus())
+                .requestedAt(e.getRequestedAt())
+                .completedAt(e.getCompletedAt())
+                .build();
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/AuthService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/AuthService.java
@@ -2,10 +2,16 @@ package com.accessplus.eventpro.api.service;
 
 import com.accessplus.eventpro.api.dto.AuthLoginRequest;
 import com.accessplus.eventpro.api.dto.AuthSignupRequest;
+import com.accessplus.eventpro.api.dto.CreateAdminUserRequest;
 import com.accessplus.eventpro.core.user.entity.UserEntity;
 
 public interface AuthService {
     UserEntity signUp(AuthSignupRequest request);
 
     AuthResult login(AuthLoginRequest request);
+
+    /**
+     * Creates a new user with ADMIN role. Only callable by existing admins.
+     */
+    UserEntity createAdminUser(CreateAdminUserRequest request);
 }

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/OrganizerService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/OrganizerService.java
@@ -31,5 +31,20 @@ public interface OrganizerService {
     List<RecentSaleResponse> getRecentSales(UUID organizerId, int limit);
 
     OrganizerInsightsResponse getInsights(UUID organizerId);
+
+    /** Gross revenue (from PAID orders) for the organizer in the given calendar year. For 1099-K reporting. */
+    java.math.BigDecimal getOrganizerRevenueForYear(UUID organizerId, int year);
+
+    /**
+     * Total platform (and payment-processing) fees withheld for the organizer in the given year.
+     * Based on stored order platform_fee (or fallback to % of gross). Used for 1099-K "fees withheld" and payouts.
+     */
+    java.math.BigDecimal getOrganizerFeesForYear(UUID organizerId, int year);
+
+    /**
+     * Total subscription/plan fees the organizer paid in the given year (Pro/Enterprise).
+     * Separate payments (organizer → platform). For 1099-K "subscription fees paid" line for their records.
+     */
+    java.math.BigDecimal getOrganizerSubscriptionPaymentsForYear(UUID organizerId, int year);
 }
 

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/TaxFormPdfService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/TaxFormPdfService.java
@@ -1,0 +1,24 @@
+package com.accessplus.eventpro.api.service;
+
+import java.io.IOException;
+
+/**
+ * Generates 1099-K tax form PDF for an organizer for a given year.
+ */
+public interface TaxFormPdfService {
+
+    /**
+     * Generates 1099-K form PDF for the given organizer and tax year.
+     *
+     * @param recipientName            Organizer display name (e.g. first + last or email)
+     * @param recipientEmail           Organizer email
+     * @param year                     Tax year (e.g. 2025)
+     * @param grossAmount              Gross payment amount for the year (IRS 1099-K Box 1)
+     * @param feesWithheld             Total fees withheld from ticket sales (platform + per-ticket); if null or zero, not shown
+     * @param subscriptionPaymentsForYear Total subscription/plan fees the organizer paid this year (Pro/Enterprise); if null or zero, not shown
+     * @return PDF bytes
+     */
+    byte[] generate1099KPdf(String recipientName, String recipientEmail, int year,
+                            java.math.BigDecimal grossAmount, java.math.BigDecimal feesWithheld,
+                            java.math.BigDecimal subscriptionPaymentsForYear) throws IOException;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/VerificationService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/VerificationService.java
@@ -1,8 +1,10 @@
 package com.accessplus.eventpro.api.service;
 
+import com.accessplus.eventpro.api.dto.PendingVerificationResponse;
 import com.accessplus.eventpro.api.dto.SubmitVerificationRequest;
 import com.accessplus.eventpro.api.dto.VerificationStatusResponse;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface VerificationService {
@@ -10,4 +12,13 @@ public interface VerificationService {
     VerificationStatusResponse getStatus(UUID organizerId);
 
     void submitVerification(UUID organizerId, SubmitVerificationRequest request);
+
+    /** Admin: approve a PENDING KYC submission; sets user verified. */
+    void approveSubmission(UUID submissionId);
+
+    /** Admin: reject a PENDING KYC submission; sets user rejected and stores reason. */
+    void rejectSubmission(UUID submissionId, String reason);
+
+    /** List PENDING KYC submissions for admin review. */
+    List<PendingVerificationResponse> listPendingSubmissions(int limit);
 }

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/AuthServiceImpl.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.accessplus.eventpro.api.service.impl;
 
 import com.accessplus.eventpro.api.dto.AuthLoginRequest;
 import com.accessplus.eventpro.api.dto.AuthSignupRequest;
+import com.accessplus.eventpro.api.dto.CreateAdminUserRequest;
 import com.accessplus.eventpro.api.service.AuthResult;
 import com.accessplus.eventpro.api.service.AuthService;
 import com.accessplus.eventpro.core.security.JwtService;
@@ -86,5 +87,20 @@ public class AuthServiceImpl implements AuthService {
             throw new ValidationException("Invalid role: " + role);
         }
         return normalized;
+    }
+
+    @Override
+    public UserEntity createAdminUser(CreateAdminUserRequest request) {
+        String email = normalizeEmail(request.getEmail());
+        String passwordHash = passwordEncoder.encode(request.getPassword());
+        log.info("Creating admin user: email={}", email);
+        return userService.createUser(
+                email,
+                passwordHash,
+                request.getFirstName(),
+                request.getLastName(),
+                request.getPhoneNumber(),
+                "ADMIN"
+        );
     }
 }

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/OrganizerServiceImpl.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/OrganizerServiceImpl.java
@@ -8,6 +8,7 @@ import com.accessplus.eventpro.api.dto.OrganizerInsightsResponse;
 import com.accessplus.eventpro.api.dto.OrganizerSummaryResponse;
 import com.accessplus.eventpro.api.dto.PayoutEligibilityDto;
 import com.accessplus.eventpro.api.dto.RecentSaleResponse;
+import com.accessplus.eventpro.api.config.PlatformTierFeeProperties;
 import com.accessplus.eventpro.api.service.OrganizerService;
 import com.accessplus.eventpro.core.notification.service.NotificationService;
 import com.accessplus.eventpro.core.user.entity.UserEntity;
@@ -22,17 +23,23 @@ import com.accessplus.eventpro.shared.entity.TicketEntity;
 import com.accessplus.eventpro.shared.enums.OrderStatus;
 import com.accessplus.eventpro.shared.enums.TicketStatus;
 import com.accessplus.eventpro.event.ticket.repository.TicketRepository;
+import com.accessplus.eventpro.api.subscription.repository.SubscriptionPaymentRepository;
 import com.accessplus.eventpro.shared.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -55,11 +62,17 @@ public class OrganizerServiceImpl implements OrganizerService {
     private final OrderItemRepository orderItemRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
+    private final SubscriptionPaymentRepository subscriptionPaymentRepository;
+    private final PlatformTierFeeProperties tierFeeProperties;
+
+    @Value("${eventpro.payout.pending-hold-days:3}")
+    private int pendingHoldDays;
 
     @Override
     public OrganizerSummaryResponse getOrganizerSummary(UUID organizerId) {
         log.debug("Getting organizer summary: organizerId={}", organizerId);
         List<EventEntity> events = eventRepository.findByOrganizerId(organizerId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        Set<UUID> eventIds = events.stream().map(EventEntity::getId).collect(Collectors.toSet());
         long eventsHosted = events.size();
         long ticketsSold = 0;
         BigDecimal totalRevenue = BigDecimal.ZERO;
@@ -82,22 +95,118 @@ public class OrganizerServiceImpl implements OrganizerService {
             totalRevenue = totalRevenue.add(eventRevenue);
         }
         UserEntity user = userRepository.findById(organizerId).orElse(null);
-        String riskLevel = user != null && user.getRiskLevel() != null ? user.getRiskLevel() : "LOW";
         String tier = user != null && user.getSubscriptionTier() != null ? user.getSubscriptionTier().toUpperCase() : "BASIC";
+        BigDecimal totalFeesLifeToDate = getOrganizerFeesLifeToDate(organizerId, eventIds, totalRevenue);
+        String feeRateLabel = formatFeeRateLabel(tier);
+        String riskLevel = user != null && user.getRiskLevel() != null ? user.getRiskLevel() : "LOW";
         boolean w9Submitted = user != null && Boolean.TRUE.equals(user.getW9Submitted());
         PayoutEligibilityDto payoutEligibility = computePayoutEligibility(tier, riskLevel);
+        // Pending = net (revenue − fees) from orders in the last N days; available = rest.
+        BigDecimal totalNet = totalRevenue.subtract(totalFeesLifeToDate).max(BigDecimal.ZERO);
+        BigDecimal pendingNet = getOrganizerPendingNet(organizerId, eventIds, tier);
+        BigDecimal pendingBalance = pendingNet.min(totalNet);
+        BigDecimal availableBalance = totalNet.subtract(pendingBalance).max(BigDecimal.ZERO);
         return OrganizerSummaryResponse.builder()
                 .eventsHosted(eventsHosted)
                 .ticketsSold(ticketsSold)
                 .ticketsSoldTrendPercent(null)
                 .totalRevenue(totalRevenue)
-                .availableBalance(BigDecimal.ZERO) // Placeholder until payout service
-                .pendingBalance(BigDecimal.ZERO) // Placeholder: funds in 1–3 day holding
+                .platformFeesWithheld(totalFeesLifeToDate)
+                .platformFeeRateLabel(feeRateLabel)
+                .availableBalance(availableBalance)
+                .pendingBalance(pendingBalance)
+                .pendingHoldDays(pendingHoldDays > 0 ? pendingHoldDays : null)
                 .riskFlagged(false)
                 .riskLevel(riskLevel)
                 .w9Submitted(w9Submitted)
                 .payoutEligibility(payoutEligibility)
                 .build();
+    }
+
+    /**
+     * Organizer's net (revenue − fees) from PAID orders in the last pendingHoldDays.
+     * Used to split total net into "pending" (in hold) vs "available" for payout.
+     */
+    private BigDecimal getOrganizerPendingNet(UUID organizerId, Set<UUID> eventIds, String tier) {
+        if (eventIds.isEmpty() || pendingHoldDays <= 0) return BigDecimal.ZERO;
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime cutoff = now.minusDays(pendingHoldDays);
+        // End 1s in future so orders created in the same second are included (BETWEEN inclusive)
+        LocalDateTime end = now.plusSeconds(1);
+        // Use createdAt (set by Hibernate on insert) so we catch all PAID orders in the window
+        // even if order_date were missing or out of sync in any code path
+        Page<OrderEntity> ordersPage = orderRepository.findByStatusAndCreatedAtBetween(
+                OrderStatus.PAID, cutoff, end, PageRequest.of(0, Integer.MAX_VALUE));
+        int totalOrdersInRange = ordersPage.getNumberOfElements();
+        if (totalOrdersInRange > 0) {
+            log.debug("getOrganizerPendingNet: organizerId={}, cutoff={}, end={}, paidOrdersInRange={}",
+                    organizerId, cutoff, end, totalOrdersInRange);
+        }
+        double feePercent = tierFeeProperties.getFeePercentForTier(tier);
+        BigDecimal feePerTicket = tierFeeProperties.getFeePerTicketForTier(tier);
+        BigDecimal revenue = BigDecimal.ZERO;
+        BigDecimal fees = BigDecimal.ZERO;
+        for (OrderEntity order : ordersPage.getContent()) {
+            BigDecimal organizerRevenueFromOrder = BigDecimal.ZERO;
+            int organizerTicketCount = 0;
+            for (OrderItemEntity oi : orderItemRepository.findByOrderId(order.getId())) {
+                TicketEntity ticket = ticketRepository.findById(oi.getTicketId()).orElse(null);
+                if (ticket != null && eventIds.contains(ticket.getEventId())) {
+                    BigDecimal lineTotal = oi.getPrice().multiply(BigDecimal.valueOf(oi.getQuantity()));
+                    organizerRevenueFromOrder = organizerRevenueFromOrder.add(lineTotal);
+                    organizerTicketCount += oi.getQuantity();
+                }
+            }
+            if (organizerRevenueFromOrder.compareTo(BigDecimal.ZERO) <= 0) continue;
+            revenue = revenue.add(organizerRevenueFromOrder);
+            BigDecimal percentFee = organizerRevenueFromOrder.multiply(BigDecimal.valueOf(feePercent)).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+            BigDecimal flatFee = feePerTicket.multiply(BigDecimal.valueOf(organizerTicketCount)).setScale(2, RoundingMode.HALF_UP);
+            fees = fees.add(percentFee).add(flatFee);
+        }
+        return revenue.subtract(fees).max(BigDecimal.ZERO);
+    }
+
+    /**
+     * Life-to-date platform fees (withheld from ticket sales) for this organizer.
+     * Uses tier-based rates from Pricing page: Basic 3.5%+$0.99, Pro 2.9%+$0.79, Enterprise 2.5%+$0.49 per ticket.
+     */
+    private BigDecimal getOrganizerFeesLifeToDate(UUID organizerId, Set<UUID> eventIds, BigDecimal totalRevenue) {
+        if (eventIds.isEmpty()) return BigDecimal.ZERO;
+        String tier = userRepository.findById(organizerId).map(UserEntity::getSubscriptionTier).orElse("BASIC");
+        double feePercent = tierFeeProperties.getFeePercentForTier(tier);
+        BigDecimal feePerTicket = tierFeeProperties.getFeePerTicketForTier(tier);
+        Page<OrderEntity> ordersPage = orderRepository.findByStatus(OrderStatus.PAID, PageRequest.of(0, Integer.MAX_VALUE));
+        BigDecimal totalFees = BigDecimal.ZERO;
+        for (OrderEntity order : ordersPage.getContent()) {
+            BigDecimal organizerRevenueFromOrder = BigDecimal.ZERO;
+            int organizerTicketCount = 0;
+            for (OrderItemEntity oi : orderItemRepository.findByOrderId(order.getId())) {
+                TicketEntity ticket = ticketRepository.findById(oi.getTicketId()).orElse(null);
+                if (ticket != null && eventIds.contains(ticket.getEventId())) {
+                    BigDecimal lineTotal = oi.getPrice().multiply(BigDecimal.valueOf(oi.getQuantity()));
+                    organizerRevenueFromOrder = organizerRevenueFromOrder.add(lineTotal);
+                    organizerTicketCount += oi.getQuantity();
+                }
+            }
+            if (organizerRevenueFromOrder.compareTo(BigDecimal.ZERO) <= 0) continue;
+            BigDecimal percentFee = organizerRevenueFromOrder.multiply(BigDecimal.valueOf(feePercent)).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+            BigDecimal flatFee = feePerTicket.multiply(BigDecimal.valueOf(organizerTicketCount)).setScale(2, RoundingMode.HALF_UP);
+            totalFees = totalFees.add(percentFee).add(flatFee);
+        }
+        return totalFees;
+    }
+
+    /** e.g. "2.9% + $0.79 per ticket (Pro)" for dashboard display. */
+    private String formatFeeRateLabel(String tier) {
+        if (tier == null) tier = "BASIC";
+        double pct = tierFeeProperties.getFeePercentForTier(tier);
+        BigDecimal perTicket = tierFeeProperties.getFeePerTicketForTier(tier);
+        String tierName = switch (tier.toUpperCase()) {
+            case "PRO" -> "Pro";
+            case "ENTERPRISE" -> "Enterprise";
+            default -> "Basic";
+        };
+        return String.format("%s%% + $%s per ticket (%s)", pct, perTicket.setScale(2, RoundingMode.HALF_UP), tierName);
     }
 
     /**
@@ -126,6 +235,67 @@ public class OrganizerServiceImpl implements OrganizerService {
                 .instant100(instant100)
                 .label(label)
                 .build();
+    }
+
+    @Override
+    public BigDecimal getOrganizerRevenueForYear(UUID organizerId, int year) {
+        LocalDateTime start = LocalDateTime.of(year, 1, 1, 0, 0, 0);
+        LocalDateTime end = LocalDateTime.of(year, 12, 31, 23, 59, 59);
+        List<EventEntity> events = eventRepository.findByOrganizerId(organizerId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        Set<UUID> eventIds = events.stream().map(EventEntity::getId).collect(Collectors.toSet());
+        if (eventIds.isEmpty()) return BigDecimal.ZERO;
+        Page<OrderEntity> ordersPage = orderRepository.findByStatusAndOrderDateBetween(
+                OrderStatus.PAID, start, end, PageRequest.of(0, Integer.MAX_VALUE));
+        BigDecimal total = BigDecimal.ZERO;
+        for (OrderEntity order : ordersPage.getContent()) {
+            for (OrderItemEntity oi : orderItemRepository.findByOrderId(order.getId())) {
+                TicketEntity ticket = ticketRepository.findById(oi.getTicketId()).orElse(null);
+                if (ticket != null && eventIds.contains(ticket.getEventId())) {
+                    total = total.add(oi.getPrice().multiply(BigDecimal.valueOf(oi.getQuantity())));
+                }
+            }
+        }
+        return total;
+    }
+
+    @Override
+    public BigDecimal getOrganizerFeesForYear(UUID organizerId, int year) {
+        LocalDateTime start = LocalDateTime.of(year, 1, 1, 0, 0, 0);
+        LocalDateTime end = LocalDateTime.of(year, 12, 31, 23, 59, 59);
+        List<EventEntity> events = eventRepository.findByOrganizerId(organizerId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        Set<UUID> eventIds = events.stream().map(EventEntity::getId).collect(Collectors.toSet());
+        if (eventIds.isEmpty()) return BigDecimal.ZERO;
+        String tier = userRepository.findById(organizerId).map(UserEntity::getSubscriptionTier).orElse("BASIC");
+        double feePercent = tierFeeProperties.getFeePercentForTier(tier);
+        BigDecimal feePerTicket = tierFeeProperties.getFeePerTicketForTier(tier);
+        Page<OrderEntity> ordersPage = orderRepository.findByStatusAndOrderDateBetween(
+                OrderStatus.PAID, start, end, PageRequest.of(0, Integer.MAX_VALUE));
+        BigDecimal totalFees = BigDecimal.ZERO;
+        for (OrderEntity order : ordersPage.getContent()) {
+            BigDecimal organizerRevenueFromOrder = BigDecimal.ZERO;
+            int organizerTicketCount = 0;
+            for (OrderItemEntity oi : orderItemRepository.findByOrderId(order.getId())) {
+                TicketEntity ticket = ticketRepository.findById(oi.getTicketId()).orElse(null);
+                if (ticket != null && eventIds.contains(ticket.getEventId())) {
+                    organizerRevenueFromOrder = organizerRevenueFromOrder.add(
+                            oi.getPrice().multiply(BigDecimal.valueOf(oi.getQuantity())));
+                    organizerTicketCount += oi.getQuantity();
+                }
+            }
+            if (organizerRevenueFromOrder.compareTo(BigDecimal.ZERO) <= 0) continue;
+            BigDecimal percentFee = organizerRevenueFromOrder.multiply(BigDecimal.valueOf(feePercent)).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+            BigDecimal flatFee = feePerTicket.multiply(BigDecimal.valueOf(organizerTicketCount)).setScale(2, RoundingMode.HALF_UP);
+            totalFees = totalFees.add(percentFee).add(flatFee);
+        }
+        return totalFees;
+    }
+
+    @Override
+    public BigDecimal getOrganizerSubscriptionPaymentsForYear(UUID organizerId, int year) {
+        Instant start = LocalDateTime.of(year, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC);
+        Instant end = LocalDateTime.of(year + 1, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC);
+        BigDecimal sum = subscriptionPaymentRepository.sumAmountByUserIdAndPaidAtBetween(organizerId, start, end);
+        return sum != null ? sum : BigDecimal.ZERO;
     }
 
     @Override

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/TaxFormPdfServiceImpl.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/TaxFormPdfServiceImpl.java
@@ -1,0 +1,170 @@
+package com.accessplus.eventpro.api.service.impl;
+
+import com.accessplus.eventpro.api.service.TaxFormPdfService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Generates 1099-K tax form PDF using Apache PDFBox.
+ * Produces a summary document with payer, recipient, year, and gross amount (Box 1).
+ */
+@Slf4j
+@Service
+public class TaxFormPdfServiceImpl implements TaxFormPdfService {
+
+    private static final String PAYER_NAME = "Access Plus";
+
+    @Override
+    public byte[] generate1099KPdf(String recipientName, String recipientEmail, int year,
+                                    BigDecimal grossAmount, BigDecimal feesWithheld,
+                                    BigDecimal subscriptionPaymentsForYear) throws IOException {
+        log.debug("Generating 1099-K PDF: year={}, recipient={}", year, recipientEmail);
+        boolean showFees = feesWithheld != null && feesWithheld.compareTo(BigDecimal.ZERO) > 0;
+        boolean showSubscription = subscriptionPaymentsForYear != null && subscriptionPaymentsForYear.compareTo(BigDecimal.ZERO) > 0;
+        try (PDDocument document = new PDDocument()) {
+            PDPage page = new PDPage(PDRectangle.A4);
+            document.addPage(page);
+
+            float margin = 50;
+            float pageWidth = page.getMediaBox().getWidth();
+            float pageHeight = page.getMediaBox().getHeight();
+
+            try (PDPageContentStream cs = new PDPageContentStream(document, page)) {
+                float y = pageHeight - margin;
+
+                // Title
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA_BOLD, 18);
+                cs.newLineAtOffset(margin, y);
+                cs.showText("Form 1099-K - Payment Card and Third Party Network Transactions");
+                cs.endText();
+                y -= 28;
+
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA, 10);
+                cs.newLineAtOffset(margin, y);
+                cs.showText("This document summarizes gross payment volume for the tax year. Box 1 is required for IRS reporting. Fees may be deductible on your return.");
+                cs.endText();
+                y -= 36;
+
+                // Payer (Copy B - Payer)
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA_BOLD, 12);
+                cs.newLineAtOffset(margin, y);
+                cs.showText("Payer (Payment Settlement Entity)");
+                cs.endText();
+                y -= 18;
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA, 11);
+                cs.newLineAtOffset(margin, y);
+                cs.showText(PAYER_NAME);
+                cs.endText();
+                y -= 28;
+
+                // Recipient
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA_BOLD, 12);
+                cs.newLineAtOffset(margin, y);
+                cs.showText("Recipient");
+                cs.endText();
+                y -= 18;
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA, 11);
+                cs.newLineAtOffset(margin, y);
+                cs.showText(recipientName != null && !recipientName.isBlank() ? recipientName : "—");
+                cs.endText();
+                y -= 14;
+                cs.beginText();
+                cs.newLineAtOffset(margin, y);
+                cs.showText(recipientEmail != null ? recipientEmail : "—");
+                cs.endText();
+                y -= 28;
+
+                // Tax year
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA_BOLD, 12);
+                cs.newLineAtOffset(margin, y);
+                cs.showText("Tax year");
+                cs.endText();
+                y -= 18;
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA, 11);
+                cs.newLineAtOffset(margin, y);
+                cs.showText(String.valueOf(year));
+                cs.endText();
+                y -= 28;
+
+                // Gross amount (Box 1)
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA_BOLD, 12);
+                cs.newLineAtOffset(margin, y);
+                cs.showText("Box 1 - Gross amount of payment card/third party network transactions");
+                cs.endText();
+                y -= 18;
+                cs.beginText();
+                cs.setFont(PDType1Font.HELVETICA, 11);
+                cs.newLineAtOffset(margin, y);
+                String amountStr = grossAmount != null ? "$" + grossAmount.setScale(2, java.math.RoundingMode.HALF_UP).toString() : "$0.00";
+                cs.showText(amountStr);
+                cs.endText();
+                y -= 22;
+
+                if (showFees) {
+                    cs.beginText();
+                    cs.setFont(PDType1Font.HELVETICA_BOLD, 11);
+                    cs.newLineAtOffset(margin, y);
+                    cs.showText("Fees withheld (platform / payment processing) — for your records:");
+                    cs.endText();
+                    y -= 16;
+                    cs.beginText();
+                    cs.setFont(PDType1Font.HELVETICA, 11);
+                    cs.newLineAtOffset(margin, y);
+                    cs.showText("$" + feesWithheld.setScale(2, java.math.RoundingMode.HALF_UP).toString());
+                    cs.endText();
+                    y -= 18;
+                    BigDecimal net = (grossAmount != null ? grossAmount : BigDecimal.ZERO).subtract(feesWithheld);
+                    cs.beginText();
+                    cs.setFont(PDType1Font.HELVETICA_BOLD, 11);
+                    cs.newLineAtOffset(margin, y);
+                    cs.showText("Amount after fees (net payout basis):");
+                    cs.endText();
+                    y -= 16;
+                    cs.beginText();
+                    cs.setFont(PDType1Font.HELVETICA, 11);
+                    cs.newLineAtOffset(margin, y);
+                    cs.showText("$" + net.setScale(2, java.math.RoundingMode.HALF_UP).toString());
+                    cs.endText();
+                    y -= 22;
+                }
+                if (showSubscription) {
+                    cs.beginText();
+                    cs.setFont(PDType1Font.HELVETICA_BOLD, 11);
+                    cs.newLineAtOffset(margin, y);
+                    cs.showText("Subscription/plan fees paid this year (Pro/Enterprise — for your records):");
+                    cs.endText();
+                    y -= 16;
+                    cs.beginText();
+                    cs.setFont(PDType1Font.HELVETICA, 11);
+                    cs.newLineAtOffset(margin, y);
+                    cs.showText("$" + subscriptionPaymentsForYear.setScale(2, java.math.RoundingMode.HALF_UP).toString());
+                    cs.endText();
+                }
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            document.save(out);
+            byte[] bytes = out.toByteArray();
+            log.info("Generated 1099-K PDF: year={}, size={} bytes", year, bytes.length);
+            return bytes;
+        }
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/VerificationServiceImpl.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/service/impl/VerificationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.accessplus.eventpro.api.service.impl;
 
+import com.accessplus.eventpro.api.dto.PendingVerificationResponse;
 import com.accessplus.eventpro.api.dto.SubmitVerificationRequest;
 import com.accessplus.eventpro.api.dto.VerificationStatusResponse;
 import com.accessplus.eventpro.api.service.RiskScoringService;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -96,5 +98,68 @@ public class VerificationServiceImpl implements VerificationService {
         userRepository.save(user);
         riskScoringService.computeAndUpdateRiskScore(organizerId);
         log.info("KYC submitted for organizer: {}", organizerId);
+    }
+
+    @Override
+    @Transactional
+    public void approveSubmission(UUID submissionId) {
+        OrganizerKycSubmissionEntity submission = kycSubmissionRepository.findById(submissionId)
+                .orElseThrow(() -> new ResourceNotFoundException("KYC submission", submissionId.toString()));
+        if (!"PENDING".equals(submission.getStatus())) {
+            throw new ValidationException("Only PENDING submissions can be approved. Current status: " + submission.getStatus());
+        }
+        submission.setStatus("VERIFIED");
+        submission.setReviewedAt(Instant.now());
+        kycSubmissionRepository.save(submission);
+
+        UserEntity user = userRepository.findById(submission.getUserId())
+                .orElseThrow(() -> new ResourceNotFoundException("User", submission.getUserId().toString()));
+        user.setVerificationStatus("VERIFIED");
+        user.setIsVerified(true);
+        userRepository.save(user);
+        log.info("KYC approved: submissionId={}, userId={}", submissionId, submission.getUserId());
+    }
+
+    @Override
+    @Transactional
+    public void rejectSubmission(UUID submissionId, String reason) {
+        OrganizerKycSubmissionEntity submission = kycSubmissionRepository.findById(submissionId)
+                .orElseThrow(() -> new ResourceNotFoundException("KYC submission", submissionId.toString()));
+        if (!"PENDING".equals(submission.getStatus())) {
+            throw new ValidationException("Only PENDING submissions can be rejected. Current status: " + submission.getStatus());
+        }
+        submission.setStatus("REJECTED");
+        submission.setReviewedAt(Instant.now());
+        submission.setRejectionReason(reason != null ? reason.trim() : null);
+        kycSubmissionRepository.save(submission);
+
+        UserEntity user = userRepository.findById(submission.getUserId())
+                .orElseThrow(() -> new ResourceNotFoundException("User", submission.getUserId().toString()));
+        user.setVerificationStatus("REJECTED");
+        user.setIsVerified(false);
+        userRepository.save(user);
+        log.info("KYC rejected: submissionId={}, userId={}, reason={}", submissionId, submission.getUserId(), reason);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PendingVerificationResponse> listPendingSubmissions(int limit) {
+        List<OrganizerKycSubmissionEntity> list = kycSubmissionRepository
+                .findByStatusOrderBySubmittedAtDesc("PENDING", org.springframework.data.domain.PageRequest.of(0, limit > 0 ? limit : 50));
+        List<PendingVerificationResponse> result = new ArrayList<>();
+        for (OrganizerKycSubmissionEntity s : list) {
+            UserEntity u = userRepository.findById(s.getUserId()).orElse(null);
+            result.add(PendingVerificationResponse.builder()
+                    .id(s.getId())
+                    .userId(s.getUserId())
+                    .email(u != null ? u.getEmail() : null)
+                    .legalEntityType(s.getLegalEntityType())
+                    .addressCity(s.getAddressCity())
+                    .addressState(s.getAddressState())
+                    .submittedAt(s.getSubmittedAt())
+                    .status(s.getStatus())
+                    .build());
+        }
+        return result;
     }
 }

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/entity/SubscriptionPaymentEntity.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/entity/SubscriptionPaymentEntity.java
@@ -1,0 +1,47 @@
+package com.accessplus.eventpro.api.subscription.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "subscription_payments", indexes = {
+    @Index(name = "idx_subscription_payments_user_id", columnList = "user_id"),
+    @Index(name = "idx_subscription_payments_paid_at", columnList = "paid_at")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionPaymentEntity {
+
+    @Id
+    @GeneratedValue
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    @JdbcTypeCode(SqlTypes.UUID)
+    private UUID userId;
+
+    @Column(name = "amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal amount;
+
+    @Column(name = "paid_at", nullable = false)
+    private Instant paidAt;
+
+    @Column(name = "tier", nullable = false, length = 20)
+    private String tier;
+
+    @Column(name = "period", nullable = false, length = 20)
+    private String period = "MONTHLY";
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/repository/SubscriptionPaymentRepository.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/repository/SubscriptionPaymentRepository.java
@@ -1,0 +1,23 @@
+package com.accessplus.eventpro.api.subscription.repository;
+
+import com.accessplus.eventpro.api.subscription.entity.SubscriptionPaymentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public interface SubscriptionPaymentRepository extends JpaRepository<SubscriptionPaymentEntity, UUID> {
+
+    /**
+     * Sum of subscription payments for the organizer in the given calendar year (for 1099-K "fees paid").
+     */
+    @Query("SELECT COALESCE(SUM(s.amount), 0) FROM SubscriptionPaymentEntity s WHERE s.userId = :userId " +
+           "AND s.paidAt >= :start AND s.paidAt < :end")
+    BigDecimal sumAmountByUserIdAndPaidAtBetween(
+            @Param("userId") UUID userId,
+            @Param("start") Instant start,
+            @Param("end") Instant end);
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/SubscriptionPaymentService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/SubscriptionPaymentService.java
@@ -2,6 +2,7 @@ package com.accessplus.eventpro.api.subscription.service;
 
 import com.accessplus.eventpro.api.subscription.entity.SubscriptionPaymentEntity;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -15,4 +16,9 @@ public interface SubscriptionPaymentService {
      * Call from admin or from Stripe/billing webhook when payment succeeds.
      */
     SubscriptionPaymentEntity recordPayment(UUID userId, java.math.BigDecimal amount, String tier, String period);
+
+    /**
+     * Record a subscription payment with a specific paid-at time (e.g. from Stripe invoice.paid webhook).
+     */
+    SubscriptionPaymentEntity recordPayment(UUID userId, java.math.BigDecimal amount, String tier, String period, Instant paidAt);
 }

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/SubscriptionPaymentService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/SubscriptionPaymentService.java
@@ -1,0 +1,18 @@
+package com.accessplus.eventpro.api.subscription.service;
+
+import com.accessplus.eventpro.api.subscription.entity.SubscriptionPaymentEntity;
+
+import java.util.UUID;
+
+/**
+ * Records and queries subscription/plan payments (Pro, Enterprise).
+ * Used for 1099-K "subscription fees paid" and platform accounting.
+ */
+public interface SubscriptionPaymentService {
+
+    /**
+     * Record a subscription payment (e.g. when organizer pays for Pro/Enterprise monthly or yearly).
+     * Call from admin or from Stripe/billing webhook when payment succeeds.
+     */
+    SubscriptionPaymentEntity recordPayment(UUID userId, java.math.BigDecimal amount, String tier, String period);
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/impl/SubscriptionPaymentServiceImpl.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/impl/SubscriptionPaymentServiceImpl.java
@@ -1,0 +1,40 @@
+package com.accessplus.eventpro.api.subscription.service.impl;
+
+import com.accessplus.eventpro.api.subscription.entity.SubscriptionPaymentEntity;
+import com.accessplus.eventpro.api.subscription.repository.SubscriptionPaymentRepository;
+import com.accessplus.eventpro.api.subscription.service.SubscriptionPaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubscriptionPaymentServiceImpl implements SubscriptionPaymentService {
+
+    private final SubscriptionPaymentRepository subscriptionPaymentRepository;
+
+    @Override
+    @Transactional
+    public SubscriptionPaymentEntity recordPayment(UUID userId, BigDecimal amount, String tier, String period) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Amount must be non-negative");
+        }
+        String tierNorm = tier != null ? tier.trim().toUpperCase() : "PRO";
+        String periodNorm = (period != null && !period.isBlank()) ? period.trim().toUpperCase() : "MONTHLY";
+        SubscriptionPaymentEntity entity = new SubscriptionPaymentEntity();
+        entity.setUserId(userId);
+        entity.setAmount(amount);
+        entity.setPaidAt(Instant.now());
+        entity.setTier(tierNorm);
+        entity.setPeriod(periodNorm);
+        entity = subscriptionPaymentRepository.save(entity);
+        log.info("Recorded subscription payment: userId={}, amount={}, tier={}, period={}", userId, amount, tierNorm, periodNorm);
+        return entity;
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/impl/SubscriptionPaymentServiceImpl.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/subscription/service/impl/SubscriptionPaymentServiceImpl.java
@@ -22,15 +22,22 @@ public class SubscriptionPaymentServiceImpl implements SubscriptionPaymentServic
     @Override
     @Transactional
     public SubscriptionPaymentEntity recordPayment(UUID userId, BigDecimal amount, String tier, String period) {
+        return recordPayment(userId, amount, tier, period, Instant.now());
+    }
+
+    @Override
+    @Transactional
+    public SubscriptionPaymentEntity recordPayment(UUID userId, BigDecimal amount, String tier, String period, Instant paidAt) {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("Amount must be non-negative");
         }
         String tierNorm = tier != null ? tier.trim().toUpperCase() : "PRO";
         String periodNorm = (period != null && !period.isBlank()) ? period.trim().toUpperCase() : "MONTHLY";
+        Instant at = paidAt != null ? paidAt : Instant.now();
         SubscriptionPaymentEntity entity = new SubscriptionPaymentEntity();
         entity.setUserId(userId);
         entity.setAmount(amount);
-        entity.setPaidAt(Instant.now());
+        entity.setPaidAt(at);
         entity.setTier(tierNorm);
         entity.setPeriod(periodNorm);
         entity = subscriptionPaymentRepository.save(entity);

--- a/backend/services/modules/eventpro-api/src/main/resources/application.yml
+++ b/backend/services/modules/eventpro-api/src/main/resources/application.yml
@@ -47,6 +47,12 @@ stripe:
   secretKey: ${STRIPE_SECRET_KEY}
   publishableKey: ${STRIPE_PUBLISHABLE_KEY:}
   webhookSecret: ${STRIPE_WEBHOOK_SECRET:}
+  # Subscription Price IDs (create in Stripe Dashboard → Products → add recurring prices)
+  subscription:
+    priceIdProMonthly: ${STRIPE_PRICE_PRO_MONTHLY:}
+    priceIdProYearly: ${STRIPE_PRICE_PRO_YEARLY:}
+    priceIdEnterpriseMonthly: ${STRIPE_PRICE_ENTERPRISE_MONTHLY:}
+    priceIdEnterpriseYearly: ${STRIPE_PRICE_ENTERPRISE_YEARLY:}
 
 # Ticket reservation expiry: release reserved tickets after this many minutes if not purchased.
 # Use 10 for high-demand sales (one winner, rest rejected instantly via atomic reserve).
@@ -116,8 +122,9 @@ security:
   jwt:
     issuer: ${JWT_ISSUER:eventpro}
     accessTokenTtlSeconds: ${JWT_ACCESS_TTL_SECONDS:3600}
-    publicKey: ${JWT_PUBLIC_KEY}
-    privateKey: ${JWT_PRIVATE_KEY}
+    # When empty and profile=local, JwtConfig generates in-memory dev keys so the app can start
+    publicKey: ${JWT_PUBLIC_KEY:}
+    privateKey: ${JWT_PRIVATE_KEY:}
 
 server:
   port: 8080

--- a/backend/services/modules/eventpro-api/src/main/resources/application.yml
+++ b/backend/services/modules/eventpro-api/src/main/resources/application.yml
@@ -53,6 +53,55 @@ stripe:
 eventpro:
   ticket:
     reservation-expiry-minutes: ${EVENTPRO_RESERVATION_EXPIRY_MINUTES:15}
+  # Payout: revenue from orders in the last N days is "pending" (1–3 day hold); the rest is "available".
+  payout:
+    pending-hold-days: ${EVENTPRO_PAYOUT_PENDING_HOLD_DAYS:3}
+  # Sales tax / VAT: jurisdiction-based by buyer state (US). Pass state/country to checkout-totals.
+  # default-rate: fallback when no state or state not in map. rates-by-state: state code -> rate % (e.g. CA 7.25).
+  tax:
+    default-rate: ${EVENTPRO_TAX_DEFAULT_RATE:0}
+    rates-by-state:
+      CA: 7.25
+      NY: 8.875
+      TX: 6.25
+      FL: 6.0
+      WA: 6.5
+      IL: 6.25
+      NJ: 6.625
+      PA: 6.0
+      OH: 5.75
+      GA: 4.0
+      NC: 4.75
+      MA: 6.25
+      VA: 4.3
+      AZ: 5.6
+      CO: 2.9
+      MI: 6.0
+      MN: 6.875
+      NV: 6.85
+      MD: 6.0
+      WI: 5.0
+      MO: 4.225
+      IN: 7.0
+      TN: 7.0
+      CT: 6.35
+      OR: 0
+      MT: 0
+      NH: 0
+      DE: 0
+      AK: 0
+  # Platform fees by tier (must match Pricing page: Basic 3.5%+$0.99, Pro 2.9%+$0.79, Enterprise 2.5%+$0.49).
+  platform:
+    tiers:
+      basic:
+        fee-percent: 3.5
+        fee-per-ticket: 0.99
+      pro:
+        fee-percent: 2.9
+        fee-per-ticket: 0.79
+      enterprise:
+        fee-percent: 2.5
+        fee-per-ticket: 0.49
   # Send order confirmation email after successful payment (set false if SES not configured locally)
   notifications:
     order-confirmation-enabled: ${EVENTPRO_ORDER_CONFIRMATION_EMAIL_ENABLED:true}

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V23__orders_platform_fee.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V23__orders_platform_fee.sql
@@ -1,0 +1,4 @@
+-- Platform fee (percentage of order total) withheld per order; used for 1099-K and payouts.
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS platform_fee DECIMAL(10,2) NOT NULL DEFAULT 0;
+COMMENT ON COLUMN orders.platform_fee IS 'Platform fee withheld for this order; used for 1099-K fees withheld and net payout';

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V24__subscription_payments.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V24__subscription_payments.sql
@@ -1,0 +1,13 @@
+-- Subscription/plan payments (Pro, Enterprise): record when organizers pay for their plan (separate from ticket-sale fees).
+-- Used for 1099-K "subscription fees paid" line (for organizer records) and platform accounting.
+CREATE TABLE IF NOT EXISTS subscription_payments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    amount DECIMAL(10,2) NOT NULL CHECK (amount >= 0),
+    paid_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    tier VARCHAR(20) NOT NULL,
+    period VARCHAR(20) NOT NULL DEFAULT 'MONTHLY'
+);
+COMMENT ON TABLE subscription_payments IS 'Pro/Enterprise plan payments; record when organizer pays monthly/yearly subscription';
+CREATE INDEX IF NOT EXISTS idx_subscription_payments_user_id ON subscription_payments(user_id);
+CREATE INDEX IF NOT EXISTS idx_subscription_payments_paid_at ON subscription_payments(paid_at);

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V25__orders_tax_amount.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V25__orders_tax_amount.sql
@@ -1,0 +1,5 @@
+-- Sales tax / VAT: amount applied to order (e.g. subtotal * rate). Default 0 until tax is enabled.
+ALTER TABLE orders
+ADD COLUMN IF NOT EXISTS tax_amount NUMERIC(10, 2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN orders.tax_amount IS 'Tax (sales tax/VAT) amount for this order; 0 when tax not applied.';

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V26__payout_requests.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V26__payout_requests.sql
@@ -1,0 +1,17 @@
+-- Payout requests: organizer requests a payout; actual transfer (Stripe Connect, etc.) is processed separately.
+CREATE TABLE IF NOT EXISTS payout_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    amount NUMERIC(12, 2) NOT NULL CHECK (amount > 0),
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_payout_requests_user_id ON payout_requests(user_id);
+CREATE INDEX IF NOT EXISTS idx_payout_requests_status ON payout_requests(status);
+CREATE INDEX IF NOT EXISTS idx_payout_requests_requested_at ON payout_requests(requested_at);
+
+COMMENT ON TABLE payout_requests IS 'Organizer payout requests; actual transfer via Stripe Connect or manual process.';

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V27__orders_buyer_state.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V27__orders_buyer_state.sql
@@ -1,0 +1,7 @@
+-- Buyer state/country for jurisdiction-based sales tax (which state the purchaser was in).
+ALTER TABLE orders
+ADD COLUMN IF NOT EXISTS buyer_state VARCHAR(10),
+ADD COLUMN IF NOT EXISTS buyer_country VARCHAR(2);
+
+COMMENT ON COLUMN orders.buyer_state IS 'Purchaser state code (e.g. CA, NY) for sales tax jurisdiction; from checkout.';
+COMMENT ON COLUMN orders.buyer_country IS 'Purchaser country code (e.g. US) for tax jurisdiction.';

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V28__seed_first_admin.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V28__seed_first_admin.sql
@@ -1,0 +1,22 @@
+-- Seed one admin user when no admin exists (e.g. fresh install / dev).
+-- Default password: 'password' — change after first login.
+-- To skip this in production, remove or rename this migration before deploy.
+
+INSERT INTO users (
+    id,
+    email,
+    password_hash,
+    first_name,
+    last_name,
+    status,
+    role
+)
+SELECT
+    gen_random_uuid(),
+    'admin@eventpro.local',
+    '$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG',
+    'Admin',
+    'User',
+    'ACTIVE',
+    'ADMIN'
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE role = 'ADMIN');

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V29__users_stripe_customer_id.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V29__users_stripe_customer_id.sql
@@ -1,0 +1,6 @@
+-- Link user to Stripe Customer for subscription billing (created when user starts checkout).
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS stripe_customer_id VARCHAR(255);
+
+COMMENT ON COLUMN users.stripe_customer_id IS 'Stripe Customer ID for subscription billing; set when user creates subscription checkout';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stripe_customer_id ON users(stripe_customer_id) WHERE stripe_customer_id IS NOT NULL;

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/common/exception/GlobalExceptionHandler.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/common/exception/GlobalExceptionHandler.java
@@ -16,11 +16,13 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.Arrays;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +30,14 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final String LOCAL_PROFILE = "local";
+
+    private final Environment environment;
+
+    public GlobalExceptionHandler(Environment environment) {
+        this.environment = environment;
+    }
     
     private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
     
@@ -212,8 +222,12 @@ public class GlobalExceptionHandler {
         
         String path = extractPath(request);
         String detail = ex.getClass().getSimpleName() + ": " + (ex.getMessage() != null ? ex.getMessage() : "");
+        boolean isLocal = Arrays.asList(environment.getActiveProfiles()).contains(LOCAL_PROFILE);
+        String message = isLocal && ex.getMessage() != null && !ex.getMessage().isBlank()
+                ? ex.getMessage()
+                : "An unexpected error occurred. Please try again later.";
         ErrorResponse errorResponse = ErrorResponse.builder()
-                .message("An unexpected error occurred. Please try again later.")
+                .message(message)
                 .path(path)
                 .timestamp(Instant.now())
                 .detail(detail)

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/config/JwtConfig.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/config/JwtConfig.java
@@ -4,9 +4,11 @@ import com.accessplus.eventpro.core.security.JwtService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.security.KeyPairGenerator;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -14,26 +16,61 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
 import java.util.Base64;
 
 @Slf4j
 @Configuration
 public class JwtConfig {
 
-    private final JwtProperties jwtProperties;
+    private static final String LOCAL_PROFILE = "local";
 
-    public JwtConfig(JwtProperties jwtProperties) {
+    private final JwtProperties jwtProperties;
+    private final Environment environment;
+
+    public JwtConfig(JwtProperties jwtProperties, Environment environment) {
         this.jwtProperties = jwtProperties;
+        this.environment = environment;
     }
 
     @Bean
     public PublicKey jwtPublicKey() {
+        if (isLocalWithEmptyKeys()) {
+            return devKeyPair().getPublic();
+        }
         return parsePublicKey(jwtProperties.getPublicKey());
     }
 
     @Bean
     public PrivateKey jwtPrivateKey() {
+        if (isLocalWithEmptyKeys()) {
+            return devKeyPair().getPrivate();
+        }
         return parsePrivateKey(jwtProperties.getPrivateKey());
+    }
+
+    private boolean isLocalWithEmptyKeys() {
+        boolean isLocal = Arrays.asList(environment.getActiveProfiles()).contains(LOCAL_PROFILE);
+        String pub = jwtProperties.getPublicKey();
+        String priv = jwtProperties.getPrivateKey();
+        boolean emptyKeys = (pub == null || pub.isBlank()) && (priv == null || priv.isBlank());
+        return isLocal && emptyKeys;
+    }
+
+    private java.security.KeyPair devKeyPair;
+
+    private java.security.KeyPair devKeyPair() {
+        if (devKeyPair == null) {
+            try {
+                KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+                gen.initialize(2048);
+                devKeyPair = gen.generateKeyPair();
+                log.warn("JWT keys not set: using in-memory RSA key pair for local development only. Set JWT_PUBLIC_KEY and JWT_PRIVATE_KEY in .env for persistent tokens.");
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to generate dev JWT key pair", e);
+            }
+        }
+        return devKeyPair;
     }
 
     @Bean

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/config/JwtProperties.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/config/JwtProperties.java
@@ -17,10 +17,10 @@ public class JwtProperties {
     @Min(300)
     private long accessTokenTtlSeconds = 3600;
 
-    @NotBlank
+    /** Optional when running with profile "local" (dev keys are generated). */
     private String publicKey;
 
-    @NotBlank
+    /** Optional when running with profile "local" (dev keys are generated). */
     private String privateKey;
 
     public String getIssuer() {

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/notification/service/NotificationService.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/notification/service/NotificationService.java
@@ -31,4 +31,14 @@ public interface NotificationService {
      * @param bodyHtml HTML body (optional; if null, bodyText is used)
      */
     void sendOrganizerBroadcastEmail(String toEmail, String subject, String bodyText, String bodyHtml);
+
+    /**
+     * Sends a subscription-upgraded notification (e.g. when Stripe confirms Pro/Enterprise or trial).
+     * Does not throw; logs errors so webhook flow is not affected.
+     *
+     * @param toEmail        recipient email
+     * @param recipientName  first name or display name
+     * @param tier           new tier (PRO or ENTERPRISE)
+     */
+    void sendSubscriptionUpgradedEmail(String toEmail, String recipientName, String tier);
 }

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/notification/service/impl/NotificationServiceImpl.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/notification/service/impl/NotificationServiceImpl.java
@@ -22,6 +22,9 @@ public class NotificationServiceImpl implements NotificationService {
     @Value("${eventpro.notifications.organizer-email-attendees-enabled:true}")
     private boolean organizerEmailAttendeesEnabled;
 
+    @Value("${eventpro.notifications.subscription-upgraded-enabled:true}")
+    private boolean subscriptionUpgradedEnabled;
+
     @Override
     public void sendOrderConfirmationEmail(String toEmail, String recipientName, String orderNumber,
                                            String eventName, BigDecimal totalAmount) {
@@ -56,6 +59,28 @@ public class NotificationServiceImpl implements NotificationService {
             emailService.sendCustomEmail(toEmail, subject, bodyText, bodyHtml);
         } catch (Exception e) {
             log.error("Failed to send organizer broadcast email: to={}, error={}", toEmail, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void sendSubscriptionUpgradedEmail(String toEmail, String recipientName, String tier) {
+        if (!subscriptionUpgradedEnabled) {
+            log.debug("Subscription upgraded email disabled by config, skipping: to={}", toEmail);
+            return;
+        }
+        if (toEmail == null || toEmail.isBlank()) {
+            log.warn("Cannot send subscription upgraded email: no recipient email");
+            return;
+        }
+        String name = recipientName != null && !recipientName.isBlank() ? recipientName : "there";
+        String tierLabel = (tier != null && !tier.isBlank()) ? tier : "Pro";
+        String subject = "You're now on EventPro " + tierLabel;
+        String bodyText = "Hi " + name + ",\n\nYour EventPro plan has been upgraded. You now have organizer access and can create and manage events.\n\nLog in to get started — your " + tierLabel + " plan is active.";
+        String bodyHtml = "<p>Hi " + name + ",</p><p>Your EventPro plan has been upgraded. You now have <strong>organizer access</strong> and can create and manage events.</p><p>Log in to get started — your " + tierLabel + " plan is active.</p>";
+        try {
+            emailService.sendCustomEmail(toEmail, subject, bodyText, bodyHtml);
+        } catch (Exception e) {
+            log.error("Failed to send subscription upgraded email: to={}, error={}", toEmail, e.getMessage(), e);
         }
     }
 }

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/security/SecurityConfig.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/security/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                     "/api/v1/payments/create-intent", "/api/v1/payments/create-intent/",
                     "/api/v1/payments/guest/confirm", "/api/v1/payments/guest/confirm/",
                     "/api/v1/payments/guest-reserve", "/api/v1/payments/guest-reserve/").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/webhooks/stripe").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/entity/UserEntity.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/entity/UserEntity.java
@@ -51,6 +51,10 @@ public class UserEntity extends BaseEntity {
     @Column(name = "subscription_tier", length = 20, nullable = false)
     private String subscriptionTier = "BASIC";
 
+    /** Stripe Customer ID for subscription billing; set when user starts subscription checkout. */
+    @Column(name = "stripe_customer_id", length = 255)
+    private String stripeCustomerId;
+
     /** True when tax/ID provided and risk check passed; gates early/instant payouts. */
     @Column(name = "is_verified", nullable = false)
     private Boolean isVerified = false;

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/repository/OrganizerKycSubmissionRepository.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/repository/OrganizerKycSubmissionRepository.java
@@ -12,4 +12,6 @@ import java.util.UUID;
 public interface OrganizerKycSubmissionRepository extends JpaRepository<OrganizerKycSubmissionEntity, UUID> {
 
     List<OrganizerKycSubmissionEntity> findByUserIdOrderBySubmittedAtDesc(UUID userId, Pageable pageable);
+
+    List<OrganizerKycSubmissionEntity> findByStatusOrderBySubmittedAtDesc(String status, Pageable pageable);
 }

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/repository/UserRepository.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
     Optional<UserEntity> findByEmail(String email);
 
     Optional<UserEntity> findByEmailIgnoreCase(String email);
+
+    Optional<UserEntity> findByStripeCustomerId(String stripeCustomerId);
 }

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/service/UserService.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/service/UserService.java
@@ -39,4 +39,19 @@ public interface UserService {
      * Valid tiers: PRO, ENTERPRISE. Only allows upgrading (BASIC -> PRO -> ENTERPRISE).
      */
     UserEntity updateSubscriptionTier(UUID userId, String tier);
+
+    /** Sets Stripe Customer ID for subscription billing (idempotent). */
+    UserEntity updateStripeCustomerId(UUID userId, String stripeCustomerId);
+
+    /** Gets user by Stripe Customer ID (for webhooks). */
+    UserEntity getUserByStripeCustomerId(String stripeCustomerId);
+
+    /** Sets subscription tier without upgrade check (for Stripe webhooks: renewals, cancellations). */
+    UserEntity setSubscriptionTier(UUID userId, String tier);
+
+    /**
+     * Sets subscription tier and, when tier is PRO or ENTERPRISE, sets role to ORGANIZER (unless user is ADMIN).
+     * Use after Stripe confirms payment or when syncing from Stripe.
+     */
+    UserEntity setSubscriptionTierAndOrganizerRole(UUID userId, String tier);
 }

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/service/impl/UserServiceImpl.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/user/service/impl/UserServiceImpl.java
@@ -250,4 +250,47 @@ public class UserServiceImpl implements UserService {
         log.info("Updated subscription tier: id={}, tier={}", saved.getId(), saved.getSubscriptionTier());
         return saved;
     }
+
+    @Override
+    public UserEntity updateStripeCustomerId(UUID userId, String stripeCustomerId) {
+        log.debug("Updating Stripe customer id: userId={}", userId);
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId.toString()));
+        user.setStripeCustomerId(stripeCustomerId);
+        return userRepository.save(user);
+    }
+
+    @Override
+    public UserEntity getUserByStripeCustomerId(String stripeCustomerId) {
+        if (stripeCustomerId == null || stripeCustomerId.isBlank()) {
+            throw new ResourceNotFoundException("User", "stripeCustomerId");
+        }
+        return userRepository.findByStripeCustomerId(stripeCustomerId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "stripeCustomerId=" + stripeCustomerId));
+    }
+
+    @Override
+    public UserEntity setSubscriptionTier(UUID userId, String tier) {
+        log.debug("Setting subscription tier (billing): userId={}, tier={}", userId, tier);
+        String normalized = (tier != null && !tier.isBlank()) ? tier.trim().toUpperCase() : "BASIC";
+        if (!"BASIC".equals(normalized) && !"PRO".equals(normalized) && !"ENTERPRISE".equals(normalized)) {
+            normalized = "BASIC";
+        }
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId.toString()));
+        user.setSubscriptionTier(normalized);
+        UserEntity saved = userRepository.save(user);
+        log.info("Set subscription tier: id={}, tier={}", saved.getId(), saved.getSubscriptionTier());
+        return saved;
+    }
+
+    @Override
+    public UserEntity setSubscriptionTierAndOrganizerRole(UUID userId, String tier) {
+        UserEntity user = setSubscriptionTier(userId, tier);
+        if (user == null) return null;
+        String normalizedTier = user.getSubscriptionTier();
+        if (!"PRO".equals(normalizedTier) && !"ENTERPRISE".equals(normalizedTier)) return user;
+        if ("ADMIN".equalsIgnoreCase(user.getRole()) || "ORGANIZER".equalsIgnoreCase(user.getRole())) return user;
+        return updateUserRole(userId, "ORGANIZER");
+    }
 }

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/shared/entity/OrderEntity.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/shared/entity/OrderEntity.java
@@ -51,6 +51,22 @@ public class OrderEntity extends BaseEntity {
     @Column(name = "donation_amount", nullable = false, precision = 10, scale = 2)
     private BigDecimal donationAmount = BigDecimal.ZERO;
 
+    /** Platform fee withheld for this order (from eventpro.platform.fee-percent). Used for 1099-K and payouts. */
+    @Column(name = "platform_fee", nullable = false, precision = 10, scale = 2)
+    private BigDecimal platformFee = BigDecimal.ZERO;
+
+    /** Tax (sales tax / VAT) amount for this order. Zero when tax not applied. */
+    @Column(name = "tax_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal taxAmount = BigDecimal.ZERO;
+
+    /** Buyer state code (e.g. CA, NY) for sales tax jurisdiction. */
+    @Column(name = "buyer_state", length = 10)
+    private String buyerState;
+
+    /** Buyer country code (e.g. US) for tax jurisdiction. */
+    @Column(name = "buyer_country", length = 2)
+    private String buyerCountry;
+
     @NotNull(message = "Order status is required")
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 50)

--- a/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/config/PlatformFeeProvider.java
+++ b/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/config/PlatformFeeProvider.java
@@ -1,0 +1,20 @@
+package com.accessplus.eventpro.order.order.config;
+
+import java.math.BigDecimal;
+
+/**
+ * Provides platform fee rates for new orders: percentage of order total and/or flat fee per ticket.
+ * When not provided (e.g. tests), fees are treated as 0. eventpro-api provides a bean from config.
+ */
+public interface PlatformFeeProvider {
+
+    /**
+     * Platform fee as a percentage of order total (e.g. 5 = 5%). 0 means no percentage fee.
+     */
+    double getFeePercent();
+
+    /**
+     * Flat fee per ticket sold (e.g. 0.50 = $0.50 per ticket). Zero means no per-ticket fee.
+     */
+    BigDecimal getFeePerTicket();
+}

--- a/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/repository/OrderRepository.java
+++ b/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/repository/OrderRepository.java
@@ -82,6 +82,17 @@ public interface OrderRepository extends JpaRepository<OrderEntity, UUID> {
             Pageable pageable);
 
     /**
+     * Finds orders by status within a date range using createdAt (audit timestamp).
+     * Use for pending balance when order_date may not be set in all code paths.
+     */
+    @Query("SELECT o FROM OrderEntity o WHERE o.status = :status AND o.createdAt BETWEEN :startDate AND :endDate")
+    Page<OrderEntity> findByStatusAndCreatedAtBetween(
+            @Param("status") OrderStatus status,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable);
+
+    /**
      * Counts orders by status.
      * 
      * @param status the order status

--- a/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/service/OrderService.java
+++ b/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/service/OrderService.java
@@ -28,13 +28,23 @@ public interface OrderService {
      * Creates an order from the user's cart.
      * Converts cart items to order items, calculates total, generates order number,
      * and publishes order to SQS queue for processing.
-     * 
+     *
      * @param userId the UUID of the user
      * @return created OrderEntity
-     * @throws com.accessplus.eventpro.core.common.exception.ResourceNotFoundException if user not found or cart is empty
-     * @throws IllegalArgumentException if validation fails
      */
     OrderEntity createOrderFromCart(UUID userId);
+
+    /**
+     * Creates an order from the user's cart with jurisdiction-based tax.
+     * When overrideTaxAmount is not null, order total = cartTotal + overrideTaxAmount and buyer state/country are stored.
+     *
+     * @param userId the UUID of the user
+     * @param overrideTaxAmount pre-computed tax amount (from checkout-totals by state); null to use default rate
+     * @param buyerState purchaser state code (e.g. CA) for tax jurisdiction
+     * @param buyerCountry purchaser country code (e.g. US)
+     * @return created OrderEntity
+     */
+    OrderEntity createOrderFromCart(UUID userId, BigDecimal overrideTaxAmount, String buyerState, String buyerCountry);
 
     /**
      * Retrieves an order by ID.
@@ -89,13 +99,21 @@ public interface OrderService {
     OrderEntity createOrderForGuest(String guestEmail, String guestFirstName, String guestLastName,
                                     List<GuestOrderItem> items, BigDecimal totalAmount, BigDecimal donationAmount);
 
+    OrderEntity createOrderForGuest(String guestEmail, String guestFirstName, String guestLastName,
+                                    List<GuestOrderItem> items, BigDecimal totalAmount, BigDecimal donationAmount,
+                                    BigDecimal taxAmount, String buyerState, String buyerCountry);
+
     /**
      * Same as createOrderForGuest but uses pre-reserved ticket IDs (from reserveTicketsForGuest).
-     * Use when guest already reserved tickets at "Proceed to Payment".
      */
     OrderEntity createOrderForGuestWithReservedTickets(String guestEmail, String guestFirstName, String guestLastName,
                                                        List<GuestOrderItem> items, BigDecimal totalAmount,
                                                        List<UUID> reservedTicketIds, BigDecimal donationAmount);
+
+    OrderEntity createOrderForGuestWithReservedTickets(String guestEmail, String guestFirstName, String guestLastName,
+                                                       List<GuestOrderItem> items, BigDecimal totalAmount,
+                                                       List<UUID> reservedTicketIds, BigDecimal donationAmount,
+                                                       BigDecimal taxAmount, String buyerState, String buyerCountry);
 
     /**
      * Marks all tickets in the order as SOLD (reduces available count).

--- a/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/service/impl/OrderServiceImpl.java
+++ b/backend/services/modules/eventpro-order/src/main/java/com/accessplus/eventpro/order/order/service/impl/OrderServiceImpl.java
@@ -15,11 +15,13 @@ import com.accessplus.eventpro.order.order.model.GuestOrderItem;
 import com.accessplus.eventpro.shared.entity.OrderEntity;
 import com.accessplus.eventpro.shared.entity.OrderItemEntity;
 import com.accessplus.eventpro.shared.enums.OrderStatus;
+import com.accessplus.eventpro.order.order.config.PlatformFeeProvider;
 import com.accessplus.eventpro.order.order.repository.OrderItemRepository;
 import com.accessplus.eventpro.order.order.repository.OrderRepository;
 import com.accessplus.eventpro.order.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -27,12 +29,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -62,14 +66,49 @@ public class OrderServiceImpl implements OrderService {
     private final UserRepository userRepository;
     private final TicketService ticketService;
     private final SQSMessagePublisher sqsMessagePublisher;
+    private final Optional<PlatformFeeProvider> platformFeeProvider;
+
+    @Value("${eventpro.tax.default-rate:0}")
+    private double taxDefaultRate;
 
     private static final DateTimeFormatter ORDER_NUMBER_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-    /**
-     * Creates an order from the user's cart.
-     */
+    private BigDecimal computeTax(BigDecimal subtotal) {
+        if (subtotal == null || subtotal.compareTo(BigDecimal.ZERO) <= 0 || taxDefaultRate <= 0) {
+            return BigDecimal.ZERO;
+        }
+        return subtotal.multiply(BigDecimal.valueOf(taxDefaultRate)).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal computePlatformFee(BigDecimal totalAmount, int totalTicketQuantity) {
+        if (platformFeeProvider.isEmpty()) return BigDecimal.ZERO;
+        PlatformFeeProvider provider = platformFeeProvider.get();
+        BigDecimal fee = BigDecimal.ZERO;
+        if (totalAmount != null && totalAmount.compareTo(BigDecimal.ZERO) > 0) {
+            double pct = provider.getFeePercent();
+            if (pct > 0) {
+                fee = fee.add(totalAmount.multiply(BigDecimal.valueOf(pct)).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP));
+            }
+        }
+        if (totalTicketQuantity > 0) {
+            java.math.BigDecimal perTicket = provider.getFeePerTicket();
+            if (perTicket != null && perTicket.compareTo(BigDecimal.ZERO) > 0) {
+                fee = fee.add(perTicket.multiply(BigDecimal.valueOf(totalTicketQuantity)).setScale(2, RoundingMode.HALF_UP));
+            }
+        }
+        return fee;
+    }
+
     @Override
     public OrderEntity createOrderFromCart(UUID userId) {
+        return createOrderFromCart(userId, null, null, null);
+    }
+
+    /**
+     * Creates an order from the user's cart. When overrideTaxAmount is provided, uses it and stores buyer state/country for jurisdiction-based tax.
+     */
+    @Override
+    public OrderEntity createOrderFromCart(UUID userId, BigDecimal overrideTaxAmount, String buyerState, String buyerCountry) {
         log.debug("Creating order from cart: userId={}", userId);
 
         // Validate and fetch user
@@ -82,7 +121,7 @@ public class OrderServiceImpl implements OrderService {
             throw new ValidationException("Cannot create order from empty cart");
         }
 
-        // Calculate total amount
+        // Calculate total amount (subtotal)
         BigDecimal totalAmount = cartService.calculateCartTotal(userId);
         if (totalAmount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new ValidationException("Order total must be greater than 0");
@@ -91,16 +130,7 @@ public class OrderServiceImpl implements OrderService {
         // Generate unique order number
         String orderNumber = generateOrderNumber();
 
-        // Create order entity (no items yet - order must be saved first to get ID)
-        OrderEntity order = new OrderEntity();
-        order.setOrderNumber(orderNumber);
-        order.setTotalAmount(totalAmount);
-        order.setStatus(OrderStatus.PENDING);
-        order.setOrderDate(LocalDateTime.now());
-        order.setUserId(user.getId()); // Use UUID instead of relationship
-        order.setOrderItems(new ArrayList<>());
-
-        // Build order items list (do not add to order yet - orderId is required and we don't have it until order is saved)
+        // Build order items list first (so we can compute totalTickets for platform fee)
         List<OrderItemEntity> orderItems = new ArrayList<>();
         for (CartEntity cartItem : cartItems) {
             TicketEntity ticket = cartItem.getTicket();
@@ -121,6 +151,23 @@ public class OrderServiceImpl implements OrderService {
         if (orderItems.isEmpty()) {
             throw new ValidationException("Cannot create order with no valid items");
         }
+
+        int totalTickets = orderItems.stream().mapToInt(OrderItemEntity::getQuantity).sum();
+
+        BigDecimal taxAmount = overrideTaxAmount != null ? overrideTaxAmount : computeTax(totalAmount);
+        BigDecimal orderTotal = totalAmount.add(taxAmount);
+        // Create order entity (no items yet - order must be saved first to get ID)
+        OrderEntity order = new OrderEntity();
+        order.setOrderNumber(orderNumber);
+        order.setTotalAmount(orderTotal);
+        order.setTaxAmount(taxAmount);
+        if (buyerState != null && !buyerState.isBlank()) order.setBuyerState(buyerState.trim().toUpperCase());
+        if (buyerCountry != null && !buyerCountry.isBlank()) order.setBuyerCountry(buyerCountry.trim().toUpperCase());
+        order.setPlatformFee(computePlatformFee(orderTotal, totalTickets));
+        order.setStatus(OrderStatus.PENDING);
+        order.setOrderDate(LocalDateTime.now());
+        order.setUserId(user.getId()); // Use UUID instead of relationship
+        order.setOrderItems(new ArrayList<>());
 
         // Save order first so it gets an ID (required for order_items.order_id)
         OrderEntity savedOrder = orderRepository.saveAndFlush(order);
@@ -162,6 +209,13 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public OrderEntity createOrderForGuest(String guestEmail, String guestFirstName, String guestLastName,
                                            List<GuestOrderItem> items, BigDecimal totalAmount, BigDecimal donationAmount) {
+        return createOrderForGuest(guestEmail, guestFirstName, guestLastName, items, totalAmount, donationAmount, null, null, null);
+    }
+
+    @Override
+    public OrderEntity createOrderForGuest(String guestEmail, String guestFirstName, String guestLastName,
+                                           List<GuestOrderItem> items, BigDecimal totalAmount, BigDecimal donationAmount,
+                                           BigDecimal taxAmount, String buyerState, String buyerCountry) {
         log.debug("Creating guest order: email={}, itemCount={}", guestEmail, items != null ? items.size() : 0);
         if (guestEmail == null || guestEmail.isBlank()) {
             throw new ValidationException("Guest email is required");
@@ -226,13 +280,19 @@ public class OrderServiceImpl implements OrderService {
         if (totalAmount == null || totalAmount.compareTo(calculatedTotal) < 0) {
             throw new ValidationException("Order total does not match calculated amount");
         }
-        BigDecimal orderTotal = totalAmount;
+        BigDecimal tax = taxAmount != null ? taxAmount : computeTax(totalAmount);
+        BigDecimal orderTotal = taxAmount != null ? totalAmount : totalAmount.add(tax); // When tax from request, totalAmount is already final
         String orderNumber = generateOrderNumber();
+        int totalTickets = orderItems.stream().mapToInt(OrderItemEntity::getQuantity).sum();
         BigDecimal donation = donationAmount != null && donationAmount.compareTo(BigDecimal.ZERO) >= 0 ? donationAmount : BigDecimal.ZERO;
         OrderEntity order = new OrderEntity();
         order.setOrderNumber(orderNumber);
         order.setTotalAmount(orderTotal);
+        order.setTaxAmount(tax);
+        if (buyerState != null && !buyerState.isBlank()) order.setBuyerState(buyerState.trim().toUpperCase());
+        if (buyerCountry != null && !buyerCountry.isBlank()) order.setBuyerCountry(buyerCountry.trim().toUpperCase());
         order.setDonationAmount(donation);
+        order.setPlatformFee(computePlatformFee(orderTotal, totalTickets));
         order.setStatus(OrderStatus.PENDING);
         order.setOrderDate(LocalDateTime.now());
         order.setUserId(null);
@@ -333,8 +393,16 @@ public class OrderServiceImpl implements OrderService {
     public OrderEntity createOrderForGuestWithReservedTickets(String guestEmail, String guestFirstName, String guestLastName,
                                                               List<GuestOrderItem> items, BigDecimal totalAmount,
                                                               List<UUID> reservedTicketIds, BigDecimal donationAmount) {
+        return createOrderForGuestWithReservedTickets(guestEmail, guestFirstName, guestLastName, items, totalAmount, reservedTicketIds, donationAmount, null, null, null);
+    }
+
+    @Override
+    public OrderEntity createOrderForGuestWithReservedTickets(String guestEmail, String guestFirstName, String guestLastName,
+                                                              List<GuestOrderItem> items, BigDecimal totalAmount,
+                                                              List<UUID> reservedTicketIds, BigDecimal donationAmount,
+                                                              BigDecimal taxAmount, String buyerState, String buyerCountry) {
         if (reservedTicketIds == null || reservedTicketIds.isEmpty()) {
-            return createOrderForGuest(guestEmail, guestFirstName, guestLastName, items, totalAmount, donationAmount);
+            return createOrderForGuest(guestEmail, guestFirstName, guestLastName, items, totalAmount, donationAmount, taxAmount, buyerState, buyerCountry);
         }
         int expectedCount = items.stream().mapToInt(GuestOrderItem::quantity).sum();
         if (reservedTicketIds.size() != expectedCount) {
@@ -370,13 +438,19 @@ public class OrderServiceImpl implements OrderService {
         if (totalAmount == null || totalAmount.compareTo(calculatedTotal) < 0) {
             throw new ValidationException("Order total does not match calculated amount");
         }
+        BigDecimal tax = taxAmount != null ? taxAmount : computeTax(totalAmount);
+        BigDecimal orderTotal = taxAmount != null ? totalAmount : totalAmount.add(tax);
         BigDecimal donation = donationAmount != null && donationAmount.compareTo(BigDecimal.ZERO) >= 0 ? donationAmount : BigDecimal.ZERO;
-        BigDecimal orderTotal = totalAmount;
         String orderNumber = generateOrderNumber();
+        int totalTickets = orderItems.stream().mapToInt(OrderItemEntity::getQuantity).sum();
         OrderEntity order = new OrderEntity();
         order.setOrderNumber(orderNumber);
         order.setTotalAmount(orderTotal);
+        order.setTaxAmount(tax);
+        if (buyerState != null && !buyerState.isBlank()) order.setBuyerState(buyerState.trim().toUpperCase());
+        if (buyerCountry != null && !buyerCountry.isBlank()) order.setBuyerCountry(buyerCountry.trim().toUpperCase());
         order.setDonationAmount(donation);
+        order.setPlatformFee(computePlatformFee(orderTotal, totalTickets));
         order.setStatus(OrderStatus.PENDING);
         order.setOrderDate(LocalDateTime.now());
         order.setUserId(null);

--- a/backend/services/modules/eventpro-order/src/test/java/com/accessplus/eventpro/order/order/service/impl/OrderServiceImplTest.java
+++ b/backend/services/modules/eventpro-order/src/test/java/com/accessplus/eventpro/order/order/service/impl/OrderServiceImplTest.java
@@ -11,9 +11,12 @@ import com.accessplus.eventpro.shared.enums.TicketType;
 import com.accessplus.eventpro.order.cart.entity.CartEntity;
 import com.accessplus.eventpro.order.cart.service.CartService;
 import com.accessplus.eventpro.shared.entity.OrderEntity;
+import com.accessplus.eventpro.shared.entity.OrderItemEntity;
 import com.accessplus.eventpro.shared.enums.OrderStatus;
+import com.accessplus.eventpro.order.order.config.PlatformFeeProvider;
 import com.accessplus.eventpro.order.order.repository.OrderItemRepository;
 import com.accessplus.eventpro.order.order.repository.OrderRepository;
+import com.accessplus.eventpro.event.ticket.service.TicketService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,7 +61,12 @@ class OrderServiceImplTest {
     @Mock
     private SQSMessagePublisher sqsMessagePublisher;
 
-    @InjectMocks
+    @Mock
+    private TicketService ticketService;
+
+    @Mock
+    private PlatformFeeProvider platformFeeProvider;
+
     private OrderServiceImpl orderService;
 
     private UUID userId;
@@ -102,6 +110,11 @@ class OrderServiceImplTest {
         order.setOrderDate(LocalDateTime.now());
         order.setUserId(user.getId());
         order.setOrderItems(new ArrayList<>());
+
+        orderService = new OrderServiceImpl(orderRepository, orderItemRepository, cartService, userRepository,
+                ticketService, sqsMessagePublisher, Optional.of(platformFeeProvider));
+        when(platformFeeProvider.getFeePercent()).thenReturn(0.0);
+        when(platformFeeProvider.getFeePerTicket()).thenReturn(java.math.BigDecimal.ZERO);
     }
 
     // ========== createOrderFromCart Tests ==========
@@ -116,11 +129,12 @@ class OrderServiceImplTest {
         when(cartService.getUserCart(userId)).thenReturn(cartItems);
         when(cartService.calculateCartTotal(userId)).thenReturn(new BigDecimal("100.00"));
         when(orderRepository.existsByOrderNumber(anyString())).thenReturn(false);
-        when(orderRepository.save(any(OrderEntity.class))).thenAnswer(invocation -> {
+        when(orderRepository.saveAndFlush(any(OrderEntity.class))).thenAnswer(invocation -> {
             OrderEntity savedOrder = invocation.getArgument(0);
             savedOrder.setId(orderId);
             return savedOrder;
         });
+        when(orderItemRepository.saveAndFlush(any(OrderItemEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
         doNothing().when(sqsMessagePublisher).publishOrderMessage(any());
         doNothing().when(cartService).clearCart(userId);
 
@@ -138,7 +152,7 @@ class OrderServiceImplTest {
         verify(userRepository).findById(userId);
         verify(cartService).getUserCart(userId);
         verify(cartService).calculateCartTotal(userId);
-        verify(orderRepository).save(any(OrderEntity.class));
+        verify(orderRepository).saveAndFlush(any(OrderEntity.class));
         verify(sqsMessagePublisher).publishOrderMessage(any());
         verify(cartService).clearCart(userId);
     }
@@ -152,7 +166,7 @@ class OrderServiceImplTest {
         assertThrows(ResourceNotFoundException.class, () -> 
                 orderService.createOrderFromCart(userId));
         verify(cartService, never()).getUserCart(any());
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test
@@ -164,7 +178,7 @@ class OrderServiceImplTest {
         // When/Then
         assertThrows(ValidationException.class, () -> 
                 orderService.createOrderFromCart(userId));
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test
@@ -180,7 +194,7 @@ class OrderServiceImplTest {
         // When/Then
         assertThrows(ValidationException.class, () -> 
                 orderService.createOrderFromCart(userId));
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test
@@ -193,11 +207,12 @@ class OrderServiceImplTest {
         when(cartService.getUserCart(userId)).thenReturn(cartItems);
         when(cartService.calculateCartTotal(userId)).thenReturn(new BigDecimal("100.00"));
         when(orderRepository.existsByOrderNumber(anyString())).thenReturn(false);
-        when(orderRepository.save(any(OrderEntity.class))).thenAnswer(invocation -> {
+        when(orderRepository.saveAndFlush(any(OrderEntity.class))).thenAnswer(invocation -> {
             OrderEntity savedOrder = invocation.getArgument(0);
             savedOrder.setId(orderId);
             return savedOrder;
         });
+        when(orderItemRepository.saveAndFlush(any(OrderItemEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
         doThrow(new RuntimeException("SQS error")).when(sqsMessagePublisher).publishOrderMessage(any());
         doNothing().when(cartService).clearCart(userId);
 
@@ -206,7 +221,7 @@ class OrderServiceImplTest {
 
         // Then - Order should still be created even if SQS publish fails
         assertNotNull(result);
-        verify(orderRepository).save(any(OrderEntity.class));
+        verify(orderRepository).saveAndFlush(any(OrderEntity.class));
         verify(cartService).clearCart(userId);
     }
 
@@ -329,7 +344,7 @@ class OrderServiceImplTest {
         // When/Then
         assertThrows(ResourceNotFoundException.class, () -> 
                 orderService.updateOrderStatus(orderId, OrderStatus.PAID));
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test
@@ -341,7 +356,7 @@ class OrderServiceImplTest {
         // When/Then
         assertThrows(IllegalStateException.class, () -> 
                 orderService.updateOrderStatus(orderId, OrderStatus.REFUNDED));
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test
@@ -353,7 +368,7 @@ class OrderServiceImplTest {
         // When/Then
         assertThrows(IllegalStateException.class, () -> 
                 orderService.updateOrderStatus(orderId, OrderStatus.CANCELLED));
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test
@@ -365,7 +380,7 @@ class OrderServiceImplTest {
         // When/Then
         assertThrows(IllegalStateException.class, () -> 
                 orderService.updateOrderStatus(orderId, OrderStatus.PAID));
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test
@@ -377,7 +392,7 @@ class OrderServiceImplTest {
         // When/Then
         assertThrows(IllegalStateException.class, () -> 
                 orderService.updateOrderStatus(orderId, OrderStatus.PAID));
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any(OrderEntity.class));
     }
 
     @Test

--- a/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/service/PaymentService.java
+++ b/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/service/PaymentService.java
@@ -23,13 +23,25 @@ public interface PaymentService {
     
     /**
      * Processes payment and creates order from cart.
-     * 
+     *
      * @param userId user ID
      * @param paymentIntentId Stripe payment intent ID
      * @return created order
-     * @throws RuntimeException if payment processing fails
      */
     OrderEntity processPayment(UUID userId, String paymentIntentId);
+
+    /**
+     * Processes payment and creates order from cart with jurisdiction-based tax.
+     * When taxAmount is not null, order total = cartTotal + taxAmount and buyerState/buyerCountry are stored.
+     *
+     * @param userId user ID
+     * @param paymentIntentId Stripe payment intent ID
+     * @param taxAmount pre-computed tax from checkout-totals (by state); null to use default
+     * @param buyerState purchaser state code (e.g. CA)
+     * @param buyerCountry purchaser country code (e.g. US)
+     * @return created order
+     */
+    OrderEntity processPayment(UUID userId, String paymentIntentId, BigDecimal taxAmount, String buyerState, String buyerCountry);
 
     /**
      * Processes payment for a guest (no account) and creates order from provided items.
@@ -40,5 +52,13 @@ public interface PaymentService {
     OrderEntity processGuestPayment(String paymentIntentId, String guestEmail, String guestFirstName,
                                     String guestLastName, List<GuestOrderItem> items, BigDecimal totalAmount,
                                     List<UUID> reservedTicketIds, BigDecimal donationAmount);
+
+    /**
+     * Guest payment with optional tax jurisdiction (state, country, taxAmount for order record).
+     */
+    OrderEntity processGuestPayment(String paymentIntentId, String guestEmail, String guestFirstName,
+                                    String guestLastName, List<GuestOrderItem> items, BigDecimal totalAmount,
+                                    List<UUID> reservedTicketIds, BigDecimal donationAmount,
+                                    BigDecimal taxAmount, String buyerState, String buyerCountry);
 }
 

--- a/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/service/impl/PaymentServiceImpl.java
+++ b/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/service/impl/PaymentServiceImpl.java
@@ -3,6 +3,7 @@ package com.accessplus.eventpro.payment.service.impl;
 import com.accessplus.eventpro.order.order.model.GuestOrderItem;
 import com.accessplus.eventpro.order.order.service.OrderService;
 import com.accessplus.eventpro.payment.service.PaymentService;
+import com.accessplus.eventpro.payment.stripe.model.StripeBillingAddress;
 import com.accessplus.eventpro.payment.stripe.service.StripeService;
 import com.accessplus.eventpro.shared.entity.OrderEntity;
 import com.accessplus.eventpro.shared.enums.OrderStatus;
@@ -41,9 +42,14 @@ public class PaymentServiceImpl implements PaymentService {
     @Override
     @Transactional
     public OrderEntity processPayment(UUID userId, String paymentIntentId) {
+        return processPayment(userId, paymentIntentId, null, null, null);
+    }
+
+    @Override
+    @Transactional
+    public OrderEntity processPayment(UUID userId, String paymentIntentId, BigDecimal taxAmount, String buyerState, String buyerCountry) {
         log.debug("Processing payment: userId={}, paymentIntentId={}", userId, paymentIntentId);
-        
-        // Confirm payment with Stripe
+
         PaymentIntent paymentIntent;
         try {
             paymentIntent = stripeService.confirmPayment(paymentIntentId);
@@ -51,20 +57,26 @@ public class PaymentServiceImpl implements PaymentService {
             log.error("Failed to confirm payment: {}", e.getMessage(), e);
             throw new RuntimeException("Failed to confirm payment: " + e.getMessage(), e);
         }
-        
-        // Verify payment succeeded
+
         if (!"succeeded".equals(paymentIntent.getStatus())) {
             throw new RuntimeException("Payment not succeeded. Status: " + paymentIntent.getStatus());
         }
-        
-        // Create order from cart and mark PAID (Stripe already succeeded)
-        OrderEntity order = orderService.createOrderFromCart(userId);
+
+        // Prefer Stripe-validated billing address (from card) for tax jurisdiction and order record
+        StripeBillingAddress stripeAddress = null;
+        try {
+            stripeAddress = stripeService.getBillingAddressFromPaymentIntent(paymentIntentId);
+        } catch (Exception e) {
+            log.warn("Could not retrieve billing address from Stripe: {}", e.getMessage());
+        }
+        String orderState = stripeAddress != null && stripeAddress.getState() != null ? stripeAddress.getState() : buyerState;
+        String orderCountry = stripeAddress != null && stripeAddress.getCountry() != null ? stripeAddress.getCountry() : buyerCountry;
+
+        OrderEntity order = orderService.createOrderFromCart(userId, taxAmount, orderState, orderCountry);
         order = orderService.updateOrderStatus(order.getId(), OrderStatus.PAID);
         orderService.markOrderTicketsAsSold(order);
 
-        log.info("Payment processed successfully: orderId={}, paymentIntentId={}", 
-                order.getId(), paymentIntentId);
-
+        log.info("Payment processed successfully: orderId={}, paymentIntentId={}", order.getId(), paymentIntentId);
         return order;
     }
 
@@ -73,6 +85,16 @@ public class PaymentServiceImpl implements PaymentService {
     public OrderEntity processGuestPayment(String paymentIntentId, String guestEmail, String guestFirstName,
                                            String guestLastName, List<GuestOrderItem> items, BigDecimal totalAmount,
                                            List<UUID> reservedTicketIds, BigDecimal donationAmount) {
+        return processGuestPayment(paymentIntentId, guestEmail, guestFirstName, guestLastName, items, totalAmount,
+                reservedTicketIds, donationAmount, null, null, null);
+    }
+
+    @Override
+    @Transactional
+    public OrderEntity processGuestPayment(String paymentIntentId, String guestEmail, String guestFirstName,
+                                           String guestLastName, List<GuestOrderItem> items, BigDecimal totalAmount,
+                                           List<UUID> reservedTicketIds, BigDecimal donationAmount,
+                                           BigDecimal taxAmount, String buyerState, String buyerCountry) {
         log.debug("Processing guest payment: paymentIntentId={}, guestEmail={}", paymentIntentId, guestEmail);
         PaymentIntent paymentIntent;
         try {
@@ -84,11 +106,21 @@ public class PaymentServiceImpl implements PaymentService {
         if (!"succeeded".equals(paymentIntent.getStatus())) {
             throw new RuntimeException("Payment not succeeded. Status: " + paymentIntent.getStatus());
         }
+        // Prefer Stripe-validated billing address (from card) for order record
+        StripeBillingAddress stripeAddress = null;
+        try {
+            stripeAddress = stripeService.getBillingAddressFromPaymentIntent(paymentIntentId);
+        } catch (Exception e) {
+            log.warn("Could not retrieve billing address from Stripe: {}", e.getMessage());
+        }
+        String orderState = stripeAddress != null && stripeAddress.getState() != null ? stripeAddress.getState() : buyerState;
+        String orderCountry = stripeAddress != null && stripeAddress.getCountry() != null ? stripeAddress.getCountry() : buyerCountry;
+
         OrderEntity order;
         if (reservedTicketIds != null && !reservedTicketIds.isEmpty()) {
-            order = orderService.createOrderForGuestWithReservedTickets(guestEmail, guestFirstName, guestLastName, items, totalAmount, reservedTicketIds, donationAmount);
+            order = orderService.createOrderForGuestWithReservedTickets(guestEmail, guestFirstName, guestLastName, items, totalAmount, reservedTicketIds, donationAmount, taxAmount, orderState, orderCountry);
         } else {
-            order = orderService.createOrderForGuest(guestEmail, guestFirstName, guestLastName, items, totalAmount, donationAmount);
+            order = orderService.createOrderForGuest(guestEmail, guestFirstName, guestLastName, items, totalAmount, donationAmount, taxAmount, orderState, orderCountry);
         }
         order = orderService.updateOrderStatus(order.getId(), OrderStatus.PAID);
         orderService.markOrderTicketsAsSold(order);

--- a/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/model/StripeBillingAddress.java
+++ b/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/model/StripeBillingAddress.java
@@ -1,0 +1,17 @@
+package com.accessplus.eventpro.payment.stripe.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Billing address from Stripe (e.g. from PaymentMethod after card confirmation).
+ * Used for tax jurisdiction and order record; Stripe may validate with card (AVS).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StripeBillingAddress {
+    private String state;
+    private String country;
+}

--- a/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/StripeService.java
+++ b/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/StripeService.java
@@ -1,5 +1,6 @@
 package com.accessplus.eventpro.payment.stripe.service;
 
+import com.accessplus.eventpro.payment.stripe.model.StripeBillingAddress;
 import com.stripe.exception.StripeException;
 import com.stripe.model.PaymentIntent;
 
@@ -37,5 +38,14 @@ public interface StripeService {
      * @throws StripeException if Stripe API call fails
      */
     String refundPayment(String paymentIntentId) throws StripeException;
+
+    /**
+     * Retrieves billing address from the PaymentIntent's payment method (card).
+     * Stripe validates this with the address on the user's card (AVS). Use for tax jurisdiction and order record.
+     *
+     * @param paymentIntentId Stripe payment intent ID (must be already confirmed so payment_method is set)
+     * @return billing address (state, country) if present, or null if not collected/expanded
+     */
+    StripeBillingAddress getBillingAddressFromPaymentIntent(String paymentIntentId) throws StripeException;
 }
 

--- a/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/StripeService.java
+++ b/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/StripeService.java
@@ -47,5 +47,27 @@ public interface StripeService {
      * @return billing address (state, country) if present, or null if not collected/expanded
      */
     StripeBillingAddress getBillingAddressFromPaymentIntent(String paymentIntentId) throws StripeException;
+
+    /**
+     * Creates a Stripe Customer for subscription billing (idempotent: reuse if same email).
+     *
+     * @param email customer email
+     * @param name  optional display name
+     * @return Stripe Customer ID
+     */
+    String createCustomer(String email, String name) throws StripeException;
+
+    /**
+     * Creates a Stripe Checkout Session for subscription (Pro/Enterprise).
+     * Customer must already exist. Caller should persist customer ID on user before redirecting.
+     *
+     * @param customerId        Stripe Customer ID
+     * @param priceId           Stripe Price ID (e.g. Pro monthly)
+     * @param successUrl        URL to redirect after successful payment
+     * @param cancelUrl         URL to redirect if user cancels
+     * @param clientReferenceId optional (e.g. user ID) for reference
+     * @return Checkout Session URL to redirect the user to
+     */
+    String createSubscriptionCheckoutSession(String customerId, String priceId, String successUrl, String cancelUrl, String clientReferenceId) throws StripeException;
 }
 

--- a/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/impl/StripeServiceImpl.java
+++ b/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/impl/StripeServiceImpl.java
@@ -4,13 +4,16 @@ import com.accessplus.eventpro.payment.stripe.model.StripeBillingAddress;
 import com.accessplus.eventpro.payment.stripe.service.StripeService;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Customer;
 import com.stripe.model.PaymentIntent;
 import com.stripe.model.PaymentMethod;
 import com.stripe.model.Refund;
+import com.stripe.param.CustomerCreateParams;
 import com.stripe.param.PaymentIntentCreateParams;
 import com.stripe.param.PaymentIntentConfirmParams;
 import com.stripe.param.PaymentIntentRetrieveParams;
 import com.stripe.param.RefundCreateParams;
+import com.stripe.param.checkout.SessionCreateParams;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -150,6 +153,46 @@ public class StripeServiceImpl implements StripeService {
             return null;
         }
         return new StripeBillingAddress(state, country);
+    }
+
+    @Override
+    public String createCustomer(String email, String name) throws StripeException {
+        ensureStripeConfigured();
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Email is required for Stripe Customer");
+        }
+        CustomerCreateParams params = CustomerCreateParams.builder()
+                .setEmail(email.trim().toLowerCase())
+                .setName(name != null && !name.isBlank() ? name.trim() : null)
+                .build();
+        Customer customer = Customer.create(params);
+        log.info("Created Stripe customer: id={}, email={}", customer.getId(), email);
+        return customer.getId();
+    }
+
+    @Override
+    public String createSubscriptionCheckoutSession(String customerId, String priceId, String successUrl, String cancelUrl, String clientReferenceId) throws StripeException {
+        ensureStripeConfigured();
+        if (customerId == null || customerId.isBlank() || priceId == null || priceId.isBlank()) {
+            throw new IllegalArgumentException("customerId and priceId are required");
+        }
+        SessionCreateParams.LineItem lineItem = SessionCreateParams.LineItem.builder()
+                .setPrice(priceId)
+                .setQuantity(1L)
+                .build();
+        SessionCreateParams.Builder paramsBuilder = SessionCreateParams.builder()
+                .setMode(SessionCreateParams.Mode.SUBSCRIPTION)
+                .setCustomer(customerId)
+                .addLineItem(lineItem)
+                .setSuccessUrl(successUrl)
+                .setCancelUrl(cancelUrl);
+        if (clientReferenceId != null && !clientReferenceId.isBlank()) {
+            paramsBuilder.setClientReferenceId(clientReferenceId);
+        }
+        com.stripe.model.checkout.Session session = com.stripe.model.checkout.Session.create(paramsBuilder.build());
+        String url = session.getUrl();
+        log.info("Created subscription checkout session: id={}, url={}", session.getId(), url != null ? "present" : "null");
+        return url;
     }
 }
 

--- a/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/impl/StripeServiceImpl.java
+++ b/backend/services/modules/eventpro-payment/src/main/java/com/accessplus/eventpro/payment/stripe/service/impl/StripeServiceImpl.java
@@ -1,12 +1,15 @@
 package com.accessplus.eventpro.payment.stripe.service.impl;
 
+import com.accessplus.eventpro.payment.stripe.model.StripeBillingAddress;
 import com.accessplus.eventpro.payment.stripe.service.StripeService;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.PaymentIntent;
+import com.stripe.model.PaymentMethod;
 import com.stripe.model.Refund;
 import com.stripe.param.PaymentIntentCreateParams;
 import com.stripe.param.PaymentIntentConfirmParams;
+import com.stripe.param.PaymentIntentRetrieveParams;
 import com.stripe.param.RefundCreateParams;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -111,6 +114,42 @@ public class StripeServiceImpl implements StripeService {
                 paymentIntentId, refund.getId());
         
         return refund.getId();
+    }
+
+    @Override
+    public StripeBillingAddress getBillingAddressFromPaymentIntent(String paymentIntentId) throws StripeException {
+        ensureStripeConfigured();
+        PaymentIntentRetrieveParams params = PaymentIntentRetrieveParams.builder()
+                .addExpand("payment_method")
+                .build();
+        PaymentIntent paymentIntent = PaymentIntent.retrieve(paymentIntentId, params, null);
+        Object pmObj = paymentIntent.getPaymentMethod();
+        if (pmObj == null) {
+            return null;
+        }
+        PaymentMethod pm;
+        if (pmObj instanceof PaymentMethod) {
+            pm = (PaymentMethod) pmObj;
+        } else if (pmObj instanceof com.stripe.model.ExpandableField) {
+            @SuppressWarnings("unchecked")
+            com.stripe.model.ExpandableField<PaymentMethod> field = (com.stripe.model.ExpandableField<PaymentMethod>) pmObj;
+            if (!field.isExpanded()) {
+                return null;
+            }
+            pm = field.getExpanded();
+        } else {
+            return null;
+        }
+        if (pm == null || pm.getBillingDetails() == null || pm.getBillingDetails().getAddress() == null) {
+            return null;
+        }
+        com.stripe.model.Address addr = pm.getBillingDetails().getAddress();
+        String state = addr.getState() != null && !addr.getState().isBlank() ? addr.getState().trim() : null;
+        String country = addr.getCountry() != null && !addr.getCountry().isBlank() ? addr.getCountry().trim() : null;
+        if (state == null && country == null) {
+            return null;
+        }
+        return new StripeBillingAddress(state, country);
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,13 @@ services:
     working_dir: /app
     env_file:
       - .env
+      - .env.stripe
     volumes:
       # Mount entire backend directory to access services and lambdas
       # This allows DevTools to detect changes and hot reload
       - ./backend:/app/backend
+      # Mount Stripe keys so the shell can source them (env_file can be unreliable with long values)
+      - ./.env.stripe:/app/.env.stripe:ro
       - gradle_cache:/root/.gradle
     ports:
       - "8080:8080"
@@ -90,10 +93,18 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+      # Subscription price IDs (Stripe Dashboard → Products → copy Price ID, e.g. price_xxx)
+      - STRIPE_PRICE_PRO_MONTHLY=${STRIPE_PRICE_PRO_MONTHLY:-}
+      - STRIPE_PRICE_PRO_YEARLY=${STRIPE_PRICE_PRO_YEARLY:-}
+      - STRIPE_PRICE_ENTERPRISE_MONTHLY=${STRIPE_PRICE_ENTERPRISE_MONTHLY:-}
+      - STRIPE_PRICE_ENTERPRISE_YEARLY=${STRIPE_PRICE_ENTERPRISE_YEARLY:-}
       # Enable DevTools for hot reload
       - SPRING_DEVTOOLS_RESTART_ENABLED=true
     command: >
       sh -c "
+        set -a &&
+        [ -f /app/.env.stripe ] && . /app/.env.stripe &&
+        set +a &&
         cd /app/backend/services &&
         chmod +x ./gradlew &&
         ./gradlew :eventpro-api:bootRun --no-daemon --continuous
@@ -119,9 +130,9 @@ services:
     ports:
       - "5173:5173"
     environment:
+      # Vite proxy in dev: forward /api to backend (use hostname "backend" from inside Docker)
+      - VITE_PROXY_TARGET=http://backend:8080
       # Vite reads from process.env (Docker) or .env.local file (when running directly)
-      # Docker Compose automatically reads .env file from project root
-      - VITE_API_BASE_URL=http://localhost:8080
       - VITE_AWS_REGION=us-east-1
       - VITE_S3_BUCKET_NAME=${S3_BUCKET_NAME:-eventpro-images-local}
       # Stripe: same publishable key as backend (set STRIPE_PUBLISHABLE_KEY in root .env)

--- a/docs/CREATE_FIRST_ADMIN.md
+++ b/docs/CREATE_FIRST_ADMIN.md
@@ -1,0 +1,73 @@
+# Creating the first admin user
+
+There is no separate admin signup. Use one of these approaches to get your first admin.
+
+---
+
+## Option 1: Promote an existing user (simplest)
+
+If you already have a user (e.g. from normal signup):
+
+1. Sign up or log in as that user in the app.
+2. In the database, set their role to `ADMIN`:
+
+```sql
+UPDATE users SET role = 'ADMIN' WHERE email = 'your@email.com';
+```
+
+3. Log in again (or refresh). You’ll see **Admin Dashboard** in the nav and can open `/admin`.
+
+---
+
+## Option 2: Seed admin via migration
+
+A Flyway migration can create one admin user when the DB has no admins yet.
+
+- **Migration:** `V28__seed_first_admin.sql` (see below).
+- **Seeded account:**  
+  - Email: `admin@eventpro.local`  
+  - Password: `password`  
+- **Important:** Change this password after first login (e.g. via Profile / Settings if you add a change-password flow, or by updating `password_hash` in the DB with a new BCrypt hash).
+
+The migration only runs once. To avoid affecting production, you can:
+
+- Use it only in dev/staging, or  
+- Remove/rename it before deploying to production and use Option 1 or 3 instead.
+
+---
+
+## Option 3: Insert admin manually in the DB
+
+Use this when you want a one-off admin and no migration.
+
+1. Generate a BCrypt hash for the password you want (e.g. with a small Java class using `BCryptPasswordEncoder`, or an online BCrypt tool).
+2. Insert a row into `users`:
+
+```sql
+INSERT INTO users (
+  id,
+  email,
+  password_hash,
+  first_name,
+  last_name,
+  status,
+  role
+) VALUES (
+  gen_random_uuid(),
+  'admin@yourdomain.com',
+  '$2a$10$...',  -- your BCrypt hash
+  'Admin',
+  'User',
+  'ACTIVE',
+  'ADMIN'
+);
+```
+
+3. After other migrations, the table may have more columns; they have defaults, so this minimal insert is enough. If your schema has `subscription_tier`, `is_verified`, `verification_status`, `risk_level`, `w9_submitted`, `branding_hide_platform`, etc., they will get their default values.
+
+---
+
+## After you have one admin
+
+- Log in with that admin account and go to **Admin → User Management**.
+- Use **Create admin user** to add more admins via the UI (no DB access needed).

--- a/docs/MVP_ROADMAP.md
+++ b/docs/MVP_ROADMAP.md
@@ -115,8 +115,8 @@ These match `eventpro-frontend/src/pages/Pricing.tsx`. All implementation and ga
 - **Reserved seating (Pro/Enterprise)**  
   - **Done:** Event flag `reservedSeatingEnabled`; tickets can have `seat_section`, `seat_row`, `seat_number`. Organizer: enable "Reserved seating" on event (create/update), then create seat map via "Seat map" section on event edit (sections: name, row count, seats per row, price). Public event page: "Select Seats" tab shows real seat map when reserved seating is enabled and seat map exists; add-by-ticket-id to cart. **Flow:** Enable reserved seating → Save event → Create seat map → Event page shows seating and allows seat selection and add to cart.
 
-- **Full white-label / custom branding (Pro/Enterprise)**  
-  - **Done:** User branding fields: `branding_logo_url`, `branding_primary_color`, `branding_hide_platform`. Profile UI to set logo, color, and “hide platform branding”. Event response includes organizer branding; public event page shows custom logo, applies primary color, and hides “Powered by Access Plus” when set.
+- **Full white-label / custom branding (Enterprise only)**  
+  - **Done:** User branding fields; Profile UI and backend updates gated to Enterprise. Event response includes organizer branding; public event page shows custom logo, primary color, and hides "Powered by Access Plus" when set. Fields: `branding_logo_url`, `branding_primary_color`, `branding_hide_platform`, color, and “hide platform branding”. Event response includes organizer branding; public event page shows custom logo, applies primary color, and hides “Powered by Access Plus” when set.
 
 ---
 
@@ -125,9 +125,18 @@ These match `eventpro-frontend/src/pages/Pricing.tsx`. All implementation and ga
 Before release, ensure:
 
 - [x] **Basic:** No custom domain, no add-ons, no fundraising, no early payouts, no “email attendees”, no reserved seating, no full HTML/CSS.
-- [ ] **Pro:** Add-ons + fundraising allowed; 50% early payout allowed; custom domain allowed; email attendees allowed; reserved seating allowed; no 100% instant payout, no API access, no white-label.
-- [ ] **Enterprise:** Everything in Pro + 100% instant payout, API access, white-label, and other Enterprise-only features from the pricing page.
-- [ ] **Risk scoring:** Used only to decide eligibility for 50% / 100% early payout within Pro/Enterprise; not a separate “tier” on the pricing page.
+- [x] **Pro:** Add-ons + fundraising allowed; 50% early payout allowed; custom domain allowed; email attendees allowed; reserved seating allowed; no 100% instant payout, no API access, no white-label.
+- [x] **Enterprise:** Everything in Pro + 100% instant payout, API access, white-label, and other Enterprise-only features from the pricing page.
+- [x] **Risk scoring:** Used only to decide eligibility for 50% / 100% early payout within Pro/Enterprise; not a separate “tier” on the pricing page.
+
+---
+
+## Taxes (current scope)
+
+- **1099-K tax compliance reports**  
+  Per pricing page: **Enterprise only**. Document Vault (list + download 1099-K PDF) is gated to Enterprise; Basic/Pro see an upgrade prompt. W-9 submission and $600 threshold progress remain available to all tiers (needed for payout unlock).
+- **Sales tax / VAT on ticket sales**  
+  **Implemented (default off).** Default rate is 0% (`eventpro.tax.default-rate` / `EVENTPRO_TAX_DEFAULT_RATE`). When set to a value > 0, tax is calculated at checkout (GET `/payments/checkout-totals`), shown on checkout, and order total = subtotal + tax. Tax amount is stored on the order. Jurisdiction-based rates and remittance are not yet implemented.
 
 ---
 
@@ -147,3 +156,26 @@ Before release, ensure:
 3. **API access (beta)** for Enterprise only.
 
 Use this doc as the single source of truth; keep the **Status** column and checklist updated as work completes.
+
+---
+
+## What’s left to implement
+
+**Payouts & identity**
+
+- **Bank account & real payouts:** Collect payout bank account (e.g. via Stripe Connect), store securely, and execute real payouts. Currently “Request Payout” is a placeholder; `availableBalance` / `pendingBalance` are computed from orders but no money is sent.
+- **ID verification:** Integrate Stripe Identity or Persona for ID document capture; pass session/verification ID in KYC submission; backend to verify session and drive VERIFIED/REJECTED.
+- **Risk/OFAC:** When KYC is submitted, run OFAC (or similar) check and ID verification result; set verification_status IN_PROGRESS → VERIFIED/REJECTED; optionally notify user on approval/rejection.
+- **Rejection UX:** When verification_status is REJECTED, show “Verification declined” and “Resubmit” on Profile; display rejection reason when provided.
+
+**Tax & compliance**
+
+- **Sales tax:** Jurisdiction-based rates and remittance are not fully automated (config-based state rates exist; optional: TaxJar/Avalara/Stripe Tax).
+- **1099-K:** Document Vault and gating are done; actual 1099-K generation/filing is out of scope for MVP.
+
+**Product / pricing**
+
+- **Tiered payouts execution:** Wire 50% early (Pro) and 100% instant (Enterprise) to real payout flow once bank and risk are in place.
+- **Dynamic pricing, multi-currency, SLA, on-premise:** Per pricing page, these are Enterprise; not yet implemented.
+
+See also: `docs/TODO-identity-check-and-verification.md` for the full KYC checklist.

--- a/docs/SALES_TAX_DESIGN.md
+++ b/docs/SALES_TAX_DESIGN.md
@@ -1,0 +1,40 @@
+# Sales Tax: Jurisdiction-Based (Billing Address)
+
+## How it should work
+
+Sales tax in the US is determined by **where the buyer is located** (destination-based), not by a single platform-wide rate. For **digital goods and event tickets**, the standard (Stripe, TaxJar, etc.) is to use the **billing address** for tax – not a separate “which state?” question.
+
+1. **Collect billing address at checkout**  
+   A **Billing address** section (country, state) is a normal part of checkout. Users expect it; we use state/country for tax automatically. No need to ask “which state are you buying from?” – the state comes from their billing address.
+
+2. **Look up the applicable rate**  
+   Use the buyer’s state (e.g. `CA`, `NY`) to get the tax rate for that jurisdiction. Rates can come from:
+   - A **config or DB table** of state → rate (simple, you maintain it).
+   - A **tax provider** (TaxJar, Avalara, Stripe Tax) for automatic, up-to-date rates and rules.
+
+3. **Compute tax at checkout**  
+   `GET /payments/checkout-totals?subtotal=100&state=CA&country=US` returns `tax` and `total` for that jurisdiction. Frontend shows “Tax (CA): $X.XX” and creates the payment intent for `total`.
+
+4. **Store jurisdiction on the order**  
+   Save `tax_amount` and **buyer state** (e.g. `buyer_state`) on the order for records and remittance.
+
+5. **Remittance**  
+   Remitting tax to each state is separate (filings, registrations). The design supports it by storing which state the tax was calculated for.
+
+## Implementation in this codebase
+
+- **Checkout totals API** accepts optional `state` and `country`. If provided, the backend uses **state-based rates** (e.g. `eventpro.tax.rates-by-state` in config). If not provided or unknown state, it falls back to `eventpro.tax.default-rate` (e.g. 0).
+- **US only for now:** Only `country=US` (or omitted) uses the state rate map. Other countries can be added later (e.g. VAT by country).
+- **Checkout UI** collects **State** (and **Country**) before payment (guest form and/or a “Tax location” step for logged-in users). These are sent to `getCheckoutTotals(subtotal, state, country)` and, for guest, in the confirm payload so the order can store `buyer_state`.
+- **Order** stores `tax_amount`, `buyer_state`, and `buyer_country` (migration V27) for records and remittance.
+
+### Stripe and billing address
+
+- **Frontend:** The billing address (country, state) from the checkout form is sent to Stripe when confirming the card via `confirmCardPayment(..., { payment_method: { card, billing_details: { address: { state, country } } } })`. Stripe can validate this with the address on the user’s card (AVS).
+- **Backend:** After payment is confirmed, the backend retrieves the PaymentIntent with `expand=payment_method` and reads `payment_method.billing_details.address` (state, country). That Stripe-validated address is preferred when saving `buyer_state` and `buyer_country` on the order; if Stripe has no address (e.g. card element without billing details), the request body state/country from the frontend is used as fallback.
+
+## Optional later
+
+- **Event location:** Some rules tax by event location; we have event address and could add event-based overrides.
+- **Tax provider:** Replace the config map with TaxJar/Avalara/Stripe Tax for accuracy and local rates.
+- **Zip/county** for more precise rates where needed.

--- a/docs/TODO-identity-check-and-verification.md
+++ b/docs/TODO-identity-check-and-verification.md
@@ -35,16 +35,16 @@ This document tracks remaining work to make the KYC (Know Your Customer) / Compl
 
 ## 3. Approval / Rejection Flow
 
-**Status:** Not started  
+**Status:** Implemented  
 **Priority:** High
 
-- [ ] Add **admin (or internal) API** to list pending/in-progress KYC submissions (e.g. `GET /api/v1/admin/verification-pending`).
-- [ ] Add **approve** action: set submission status to VERIFIED, set `user.verification_status = 'VERIFIED'`, set `user.is_verified = true` (and optionally set `user.risk_level`).
-- [ ] Add **reject** action: set submission status to REJECTED, set `user.verification_status = 'REJECTED'`, set `rejection_reason` on the submission.
+- [x] Add **admin API** to list pending KYC submissions: `GET /api/v1/admin/verification-pending?limit=50`.
+- [x] Add **approve** action: `POST /api/v1/admin/verification/{submissionId}/approve` — sets submission to VERIFIED, `user.verification_status = 'VERIFIED'`, `user.is_verified = true`.
+- [x] Add **reject** action: `POST /api/v1/admin/verification/{submissionId}/reject` with optional body `{ "reason": "..." }` — sets submission to REJECTED, `user.verification_status = 'REJECTED'`, stores `rejection_reason`.
 - [ ] Optionally: automated approval path when risk checks (§2) pass; automated rejection when they fail.
 - [ ] Optionally: notify the user (email/in-app) when verified or rejected.
 
-**Notes:** Without this, no one can ever become Verified and "Manage Payouts" will never unlock.
+**Notes:** Admins can now approve or reject PENDING submissions; Profile already shows REJECTED state and "Resubmit verification".
 
 ---
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -111,10 +111,18 @@ STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
 
 # Stripe Webhook Secret (for webhook signature verification)
 # Use test webhook secrets for local development: whsec_...
+# Required for subscription lifecycle (invoice.paid, subscription.updated/deleted). Webhook URL: POST /api/v1/webhooks/stripe
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
+
+# Subscription Price IDs (create in Stripe Dashboard → Products → add recurring prices for Pro/Enterprise)
+# When set, "Upgrade to Pro/Enterprise" on the Pricing page redirects to Stripe Checkout; webhooks update user tier and record payments.
+STRIPE_PRICE_PRO_MONTHLY=price_xxx
+STRIPE_PRICE_PRO_YEARLY=price_xxx
+STRIPE_PRICE_ENTERPRISE_MONTHLY=price_xxx
+STRIPE_PRICE_ENTERPRISE_YEARLY=price_xxx
 ```
 
-**Note**: For local development, you can use test keys. The application-local.yml provides default test values, but you should set real test keys for proper functionality.
+**Note**: For local development, you can use test keys. The application-local.yml provides default test values, but you should set real test keys for proper functionality. For subscriptions: create Products (e.g. "Pro", "Enterprise") and recurring Prices in Stripe Dashboard, then set the four `STRIPE_PRICE_*` env vars. If they are unset, the create-checkout-session API will return an error when users try to upgrade.
 
 ### Optional: AWS Secrets Manager
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -126,6 +126,21 @@ DB_SECRET_ARN=arn:aws:secretsmanager:us-east-1:000000000000:secret:eventpro-db-s
 STRIPE_SECRET_ARN=arn:aws:secretsmanager:us-east-1:000000000000:secret:eventpro-stripe-keys
 ```
 
+### Platform fees (by tier; match Pricing page)
+
+Fees are **tier-based** and configured in `application.yml` under `eventpro.platform.tiers` (Basic 3.5% + $0.99, Pro 2.9% + $0.79, Enterprise 2.5% + $0.49 per ticket). No env vars are required; override in yml if you need to change rates.
+
+### Payout and tax (optional)
+
+```env
+# Number of days revenue is held as "pending" before becoming "available" for payout (default: 3)
+EVENTPRO_PAYOUT_PENDING_HOLD_DAYS=3
+
+# Default sales tax rate when no state is provided (0 = no tax). Jurisdiction-based: pass state/country at checkout for state-specific rates (see eventpro.tax.rates-by-state in application.yml).
+EVENTPRO_TAX_DEFAULT_RATE=0
+```
+Rates per state are in `application.yml` under `eventpro.tax.rates-by-state` (e.g. CA: 7.25, NY: 8.875). Override or extend there; no env var for the map.
+
 ### Spring Profile
 
 ```env

--- a/eventpro-frontend/src/App.tsx
+++ b/eventpro-frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { CartProvider } from "@/contexts/CartContext";
 import { PreferencesProvider } from "@/contexts/PreferencesContext";
 import { LanguageProvider } from "@/contexts/LanguageContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { AdminLayout } from "@/components/AdminLayout";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { PageTransition } from "@/components/PageTransition";
@@ -26,6 +27,12 @@ import Login from "./pages/Login";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import Admin from "./pages/Admin";
+import AdminDashboard from "./pages/AdminDashboard";
+import AdminVerification from "./pages/AdminVerification";
+import AdminEvents from "./pages/AdminEvents";
+import AdminEventSales from "./pages/AdminEventSales";
+import AdminRevenue from "./pages/AdminRevenue";
+import AdminSubscriptionPayments from "./pages/AdminSubscriptionPayments";
 import UserManagement from "./pages/UserManagement";
 import Organizer from "./pages/Organizer";
 import EventForm from "./pages/EventForm";
@@ -34,6 +41,7 @@ import EventTickets from "./pages/EventTickets";
 import EventEnhancements from "./pages/EventEnhancements";
 import OrderHistory from "./pages/OrderHistory";
 import Pricing from "./pages/Pricing";
+import SubscriptionReturn from "./pages/SubscriptionReturn";
 import Partners from "./pages/Partners";
 import NotFound from "./pages/NotFound";
 
@@ -47,6 +55,14 @@ const AnimatedRoutes = () => {
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<PageTransition><Home /></PageTransition>} />
         <Route path="/pricing" element={<PageTransition><Pricing /></PageTransition>} />
+        <Route
+          path="/subscription/return"
+          element={
+            <ProtectedRoute>
+              <PageTransition><SubscriptionReturn /></PageTransition>
+            </ProtectedRoute>
+          }
+        />
         <Route path="/partners" element={<PageTransition><Partners /></PageTransition>} />
         <Route path="/events" element={<PageTransition><Events /></PageTransition>} />
         <Route path="/events/:id" element={<PageTransition><EventDetails /></PageTransition>} />
@@ -100,19 +116,21 @@ const AnimatedRoutes = () => {
           path="/admin"
           element={
             <ProtectedRoute allowedRoles={["ADMIN"]}>
-              <PageTransition><Admin /></PageTransition>
+              <PageTransition>
+                <AdminLayout />
+              </PageTransition>
             </ProtectedRoute>
           }
-        />
-
-        <Route
-          path="/admin/users"
-          element={
-            <ProtectedRoute allowedRoles={["ADMIN"]}>
-              <PageTransition><UserManagement /></PageTransition>
-            </ProtectedRoute>
-          }
-        />
+        >
+          <Route index element={<Admin />} />
+          <Route path="overview" element={<AdminDashboard />} />
+          <Route path="users" element={<UserManagement />} />
+          <Route path="verification" element={<AdminVerification />} />
+          <Route path="events" element={<AdminEvents />} />
+          <Route path="event-sales" element={<AdminEventSales />} />
+          <Route path="revenue" element={<AdminRevenue />} />
+          <Route path="subscription-payments" element={<AdminSubscriptionPayments />} />
+        </Route>
 
         <Route
           path="/organizer"

--- a/eventpro-frontend/src/components/AdminLayout.tsx
+++ b/eventpro-frontend/src/components/AdminLayout.tsx
@@ -1,0 +1,42 @@
+import { Navigate, Outlet, Link } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthContext";
+import { Shield } from "lucide-react";
+
+/**
+ * Wraps all admin pages. Ensures only users with ADMIN role can access.
+ * Use with ProtectedRoute(allowedRoles={["ADMIN"]}) on the parent route.
+ */
+export const AdminLayout = () => {
+  const { user, isLoading, hasRole } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!user || !hasRole("ADMIN")) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <div className="min-h-screen py-8">
+      <div className="container mx-auto px-4">
+        <div className="flex items-center gap-3 mb-6">
+          <Link
+            to="/admin"
+            className="flex items-center gap-3 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+              <Shield className="h-5 w-5 text-primary" />
+            </div>
+            <span className="font-medium">Admin</span>
+          </Link>
+        </div>
+        <Outlet />
+      </div>
+    </div>
+  );
+};

--- a/eventpro-frontend/src/components/CheckoutPaymentForm.tsx
+++ b/eventpro-frontend/src/components/CheckoutPaymentForm.tsx
@@ -6,6 +6,11 @@ import { apiService } from "@/lib/api";
 
 const STRIPE_SCRIPT_URL = "https://js.stripe.com/v3/";
 
+export interface BillingDetailsForStripe {
+  state?: string;
+  country?: string;
+}
+
 export interface CheckoutPaymentFormProps {
   clientSecret: string;
   amount: number;
@@ -14,6 +19,8 @@ export interface CheckoutPaymentFormProps {
   guestConfirm?: (paymentIntentId: string) => Promise<{ id: string }>;
   authenticatedConfirm?: (paymentIntentId: string) => Promise<{ id: string }>;
   isGuest: boolean;
+  /** Billing address from checkout form; sent to Stripe so it can validate with the card (AVS). */
+  billingDetails?: BillingDetailsForStripe;
 }
 
 declare global {
@@ -25,7 +32,12 @@ declare global {
       };
       confirmCardPayment: (
         clientSecret: string,
-        opts: { payment_method: { card: unknown } }
+        opts: {
+          payment_method: {
+            card: unknown;
+            billing_details?: { address?: { state?: string; country?: string } };
+          };
+        }
       ) => Promise<{ error?: { message?: string }; paymentIntent?: { status: string; id: string } }>;
     };
   }
@@ -65,7 +77,7 @@ function StripeNotConfigured() {
 }
 
 export function CheckoutPaymentForm(props: CheckoutPaymentFormProps) {
-  const { clientSecret, onSuccess, onError, guestConfirm, authenticatedConfirm, isGuest } = props;
+  const { clientSecret, onSuccess, onError, guestConfirm, authenticatedConfirm, isGuest, billingDetails } = props;
   const [stripeKey, setStripeKey] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -144,8 +156,20 @@ export function CheckoutPaymentForm(props: CheckoutPaymentFormProps) {
     }
     setIsSubmitting(true);
     try {
+      const paymentMethodPayload: {
+        card: unknown;
+        billing_details?: { address: { state?: string; country?: string } };
+      } = { card: cardInstanceRef.current };
+      if (billingDetails && (billingDetails.state || billingDetails.country)) {
+        paymentMethodPayload.billing_details = {
+          address: {
+            ...(billingDetails.state && { state: billingDetails.state }),
+            ...(billingDetails.country && { country: billingDetails.country }),
+          },
+        };
+      }
       const { error: confirmError, paymentIntent } = await stripe.confirmCardPayment(clientSecret, {
-        payment_method: { card: cardInstanceRef.current },
+        payment_method: paymentMethodPayload,
       });
       if (confirmError) {
         onError(confirmError.message ?? "Payment failed");

--- a/eventpro-frontend/src/components/FinancialHub.tsx
+++ b/eventpro-frontend/src/components/FinancialHub.tsx
@@ -11,6 +11,7 @@ import { Wallet, Zap } from "lucide-react";
 import { apiService } from "@/lib/api";
 import type { OrganizerSummary } from "@/types/api";
 import { useAuth } from "@/contexts/AuthContext";
+import { toast } from "sonner";
 
 const POLL_INTERVAL_MS = 30_000; // 30 seconds for near real-time
 
@@ -32,6 +33,7 @@ export function FinancialHub() {
   const { user } = useAuth();
   const [summary, setSummary] = useState<OrganizerSummary | null>(null);
   const [loading, setLoading] = useState(true);
+  const [requestingPayout, setRequestingPayout] = useState(false);
 
   const fetchFinancials = useCallback(async () => {
     try {
@@ -60,6 +62,7 @@ export function FinancialHub() {
   }, [fetchFinancials]);
 
   const totalRevenue = summary ? toNumber(summary.totalRevenue) : 0;
+  const platformFeesWithheld = summary ? toNumber(summary.platformFeesWithheld) : 0;
   const availableBalance = summary ? toNumber(summary.availableBalance) : 0;
   const pendingBalance = summary ? toNumber(summary.pendingBalance) : 0;
   const w9Submitted = Boolean(summary?.w9Submitted);
@@ -80,29 +83,40 @@ export function FinancialHub() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-        {/* Tile 1: Total Revenue (life-to-date) */}
+        {/* Tile 1: Total Revenue (life-to-date, gross) */}
         <div className={tileBase}>
           <p className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-1">
             Total Revenue
           </p>
-          <p className="text-xs text-muted-foreground/80 mb-2">Life-to-date</p>
+          <p className="text-xs text-muted-foreground/80 mb-2">Life-to-date (gross sales)</p>
           {loading ? (
             <Skeleton className="h-10 w-32 bg-white/10" />
           ) : (
-            <p className="text-3xl font-bold font-heading tabular-nums text-foreground">
-              {usdFormat.format(totalRevenue)}
-            </p>
+            <>
+              <p className="text-3xl font-bold font-heading tabular-nums text-foreground">
+                {usdFormat.format(totalRevenue)}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                {platformFeesWithheld > 0 ? (
+                  <>Platform fees ({summary?.platformFeeRateLabel ?? "per your plan"}): −{usdFormat.format(platformFeesWithheld)}</>
+                ) : (
+                  <>Platform fees: {usdFormat.format(0)} {summary?.platformFeeRateLabel && `(${summary.platformFeeRateLabel})`}</>
+                )}
+              </p>
+            </>
           )}
         </div>
 
-        {/* Tile 2: Available for Payout (most prominent, purple glow) */}
+        {/* Tile 2: Available for Payout (gross minus platform fees) */}
         <div
           className={`${tileBase} ring-1 ring-primary/20 shadow-[0_0_20px_rgba(147,51,234,0.25)] dark:shadow-[0_0_24px_rgba(147,51,234,0.3)]`}
         >
           <p className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-1">
             Available for Payout
           </p>
-          <p className="text-xs text-muted-foreground/80 mb-2">Cleared risk scoring</p>
+          <p className="text-xs text-muted-foreground/80 mb-2">
+            {platformFeesWithheld > 0 ? "After platform fees" : "Cleared risk scoring"}
+          </p>
           {loading ? (
             <Skeleton className="h-10 w-32 bg-white/10" />
           ) : (
@@ -112,18 +126,27 @@ export function FinancialHub() {
           )}
         </div>
 
-        {/* Tile 3: Pending (subtle) */}
+        {/* Tile 3: Pending (net from sales in last N days) */}
         <div className={tileBase}>
           <p className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-1">
             Pending
           </p>
-          <p className="text-xs text-muted-foreground/80 mb-2">1–3 business day hold</p>
+          <p className="text-xs text-muted-foreground/80 mb-2">
+            {summary?.pendingHoldDays
+              ? `Last ${summary.pendingHoldDays} day hold (net from recent sales)`
+              : "1–3 business day hold"}
+          </p>
           {loading ? (
             <Skeleton className="h-8 w-24 bg-white/10" />
           ) : (
-            <p className="text-2xl font-semibold tabular-nums text-muted-foreground">
-              {usdFormat.format(pendingBalance)}
-            </p>
+            <>
+              <p className="text-2xl font-semibold tabular-nums text-muted-foreground">
+                {usdFormat.format(pendingBalance)}
+              </p>
+              {pendingBalance === 0 && totalRevenue > 0 && (
+                <p className="text-xs text-muted-foreground mt-1">No sales in the hold window yet</p>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -146,18 +169,28 @@ export function FinancialHub() {
             <TooltipTrigger asChild>
               <span className="inline-block">
                 <Button
-                  disabled={!canPayout}
+                  disabled={!canPayout || requestingPayout}
                   className={`bg-gradient-to-r from-primary via-primary to-orange-500 text-white border-0 shadow-lg hover:shadow-[0_0_20px_hsl(var(--primary)_/_0.4)] transition-all ${
                     !canPayout ? "opacity-50 cursor-not-allowed" : ""
                   }`}
-                  onClick={() => {
-                    if (canPayout) {
-                      /* Navigate to payout flow or open modal when implemented */
+                  onClick={async () => {
+                    if (!canPayout || requestingPayout || availableBalance <= 0) return;
+                    setRequestingPayout(true);
+                    try {
+                      await apiService.requestPayout(availableBalance);
+                      toast.success("Payout requested. You will be notified when it is processed.");
+                      window.dispatchEvent(new Event("organizer-summary-invalidate"));
+                      fetchFinancials();
+                    } catch (e: unknown) {
+                      const msg = (e as { response?: { data?: { message?: string } } })?.response?.data?.message ?? "Request failed";
+                      toast.error(msg);
+                    } finally {
+                      setRequestingPayout(false);
                     }
                   }}
                 >
                   <Zap className="h-4 w-4 mr-2" />
-                  {payoutsPausedByTax ? "Payouts Paused: Tax Info Required" : "Instant Payout"}
+                  {requestingPayout ? "Requesting…" : payoutsPausedByTax ? "Payouts Paused: Tax Info Required" : "Instant Payout"}
                 </Button>
               </span>
             </TooltipTrigger>

--- a/eventpro-frontend/src/components/TaxCenter.tsx
+++ b/eventpro-frontend/src/components/TaxCenter.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { Shield, ShieldCheck, FileText, Download } from "lucide-react";
+import { Shield, ShieldCheck, FileText, Download, Lock } from "lucide-react";
 import { apiService } from "@/lib/api";
 import type { OrganizerSummary, TaxFormEntry } from "@/types/api";
 import { W9Modal } from "@/components/W9Modal";
+import { useAuth } from "@/contexts/AuthContext";
 
 const THRESHOLD_1099 = 600;
 const W9_REQUIRED_ABOVE = 500;
@@ -26,16 +28,19 @@ function toNum(v: unknown): number {
 const INVALUATE_EVENT = "organizer-summary-invalidate";
 
 export function TaxCenter() {
+  const { user } = useAuth();
   const [summary, setSummary] = useState<OrganizerSummary | null>(null);
   const [taxForms, setTaxForms] = useState<TaxFormEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [w9ModalOpen, setW9ModalOpen] = useState(false);
 
+  const isEnterprise = (user?.subscriptionTier ?? "").toUpperCase() === "ENTERPRISE";
+
   const fetchData = useCallback(async () => {
     try {
       const [s, forms] = await Promise.all([
         apiService.getOrganizerSummary(),
-        apiService.getOrganizerTaxForms(),
+        isEnterprise ? apiService.getOrganizerTaxForms() : Promise.resolve([]),
       ]);
       setSummary(s);
       setTaxForms(forms ?? []);
@@ -45,7 +50,7 @@ export function TaxCenter() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isEnterprise]);
 
   useEffect(() => {
     fetchData();
@@ -129,13 +134,26 @@ export function TaxCenter() {
         )}
       </div>
 
-      {/* Document Vault */}
+      {/* Document Vault (1099-K reports — Enterprise only per pricing) */}
       <div className={`${tileBase} mb-6`}>
         <h3 className="font-semibold mb-4 flex items-center gap-2">
           <FileText className="h-4 w-4 text-primary" />
           Document Vault
         </h3>
-        {loading ? (
+        {!isEnterprise ? (
+          <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 flex flex-col sm:flex-row sm:items-center gap-4">
+            <Lock className="h-10 w-10 text-primary shrink-0" />
+            <div>
+              <p className="font-medium text-foreground">1099-K reports are included in Enterprise</p>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                Download annual 1099-K tax forms and keep compliance in one place. Upgrade to Enterprise to unlock the Document Vault.
+              </p>
+            </div>
+            <Button asChild className="shrink-0 bg-gradient-to-r from-primary to-primary-glow text-primary-foreground">
+              <Link to="/pricing">View plans</Link>
+            </Button>
+          </div>
+        ) : loading ? (
           <Skeleton className="h-16 w-full rounded-lg bg-white/10" />
         ) : taxForms.length === 0 ? (
           <p className="text-sm text-muted-foreground">No tax forms yet. Forms appear here after the calendar year.</p>
@@ -163,8 +181,13 @@ export function TaxCenter() {
                   size="sm"
                   variant="outline"
                   className="bg-gradient-to-r from-primary/10 to-primary-glow/10 border-primary/30 text-primary hover:bg-primary/20"
-                  disabled={form.status !== "Available" || !form.downloadUrl}
-                  onClick={() => form.downloadUrl && window.open(form.downloadUrl)}
+                  disabled={form.status !== "Available"}
+                  onClick={() => {
+                    if (form.status !== "Available") return;
+                    const year = parseInt(form.year, 10);
+                    if (!Number.isNaN(year)) apiService.downloadOrganizerTaxFormPdf(year);
+                  }}
+                  title={form.status !== "Available" ? form.status : undefined}
                 >
                   <Download className="h-4 w-4 mr-2" />
                   Download PDF

--- a/eventpro-frontend/src/hooks/useAdminApi.ts
+++ b/eventpro-frontend/src/hooks/useAdminApi.ts
@@ -1,0 +1,70 @@
+import { useMemo } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { apiService } from "@/lib/api";
+import type { User, Event, AdminStats, EventSales, RevenueData, PendingVerification } from "@/types/api";
+import type { PageResponse } from "@/types/api";
+import type { RecordSubscriptionPaymentRequest } from "@/types/api";
+
+/**
+ * Returns admin API methods only when the current user has role ADMIN.
+ * Use this in admin-only UI so that admin APIs are never called for non-admins.
+ * Backend still enforces ADMIN; this is defense-in-depth on the client.
+ */
+export interface CreateAdminUserRequest {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber?: string;
+}
+
+export function useAdminApi(): {
+  getStats: () => Promise<AdminStats>;
+  getUsersPage: (page?: number, size?: number) => Promise<PageResponse<User>>;
+  getAllUsers: () => Promise<User[]>;
+  createAdminUser: (body: CreateAdminUserRequest) => Promise<User>;
+  updateUserRole: (userId: string, role: string) => Promise<User>;
+  updateUserStatus: (userId: string, status: string) => Promise<User>;
+  getVerificationPending: (limit?: number) => Promise<PendingVerification[]>;
+  approveVerification: (submissionId: string) => Promise<void>;
+  rejectVerification: (submissionId: string, reason?: string) => Promise<void>;
+  getEventSales: () => Promise<EventSales[]>;
+  getRevenue: (period?: string) => Promise<RevenueData[]>;
+  getEventsPage: (page?: number, size?: number) => Promise<PageResponse<Event>>;
+  updateEventStatus: (eventId: string, status: string) => Promise<Event>;
+  recordSubscriptionPayment: (body: RecordSubscriptionPaymentRequest) => Promise<{ id: string }>;
+} | null {
+  const { user } = useAuth();
+
+  return useMemo(() => {
+    if (!user || user.role !== "ADMIN") {
+      return null;
+    }
+    return {
+      getStats: () => apiService.getStats(),
+      getUsersPage: (page = 1, size = 10) =>
+        apiService.getUsersPage(page, size),
+      getAllUsers: () => apiService.getAllUsers(),
+      createAdminUser: (body: CreateAdminUserRequest) =>
+        apiService.createAdminUser(body),
+      updateUserRole: (userId: string, role: string) =>
+        apiService.updateUserRole(userId, role),
+      updateUserStatus: (userId: string, status: string) =>
+        apiService.updateUserStatus(userId, status),
+      getVerificationPending: (limit = 50) =>
+        apiService.getVerificationPending(limit),
+      approveVerification: (submissionId: string) =>
+        apiService.approveVerification(submissionId),
+      rejectVerification: (submissionId: string, reason?: string) =>
+        apiService.rejectVerification(submissionId, reason),
+      getEventSales: () => apiService.getEventSales(),
+      getRevenue: (period = "30d") => apiService.getRevenue(period),
+      getEventsPage: (page = 1, size = 10) =>
+        apiService.getEventsPage(page, size),
+      updateEventStatus: (eventId: string, status: string) =>
+        apiService.updateEventStatus(eventId, status),
+      recordSubscriptionPayment: (body: RecordSubscriptionPaymentRequest) =>
+        apiService.recordSubscriptionPayment(body),
+    };
+  }, [user?.id, user?.role]);
+}

--- a/eventpro-frontend/src/lib/api.ts
+++ b/eventpro-frontend/src/lib/api.ts
@@ -257,6 +257,23 @@ class ApiService {
     return response.data.data ?? { stripePublishableKey: "" };
   }
 
+  /** Get checkout totals including tax. Pass state/country for jurisdiction-based tax (e.g. state=CA, country=US). */
+  async getCheckoutTotals(subtotal?: number, state?: string, country?: string): Promise<import("@/types/api").CheckoutTotals> {
+    const params: Record<string, string | number> = {};
+    if (subtotal != null && subtotal >= 0) params.subtotal = subtotal;
+    if (state != null && state.trim()) params.state = state.trim();
+    if (country != null && country.trim()) params.country = country.trim();
+    const response = await this.api.get<ApiResponse<import("@/types/api").CheckoutTotals>>("/api/v1/payments/checkout-totals", { params });
+    const data = response.data.data;
+    if (!data) throw new Error("No checkout totals");
+    return {
+      subtotal: Number(data.subtotal),
+      taxRatePercent: Number(data.taxRatePercent),
+      tax: Number(data.tax),
+      total: Number(data.total),
+    };
+  }
+
   /** Create Stripe payment intent (amount in dollars). Public – works for guest. */
   async createPaymentIntent(amount: number): Promise<{ clientSecret: string }> {
     const response = await this.api.post<ApiResponse<{ clientSecret: string }>>("/api/v1/payments/create-intent", {
@@ -271,11 +288,12 @@ class ApiService {
     return response.data.data;
   }
 
-  /** Confirm payment for authenticated user (creates order from cart). */
-  async confirmPayment(paymentIntentId: string): Promise<Order> {
-    const response = await this.api.post<ApiResponse<Order>>("/api/v1/payments/confirm", {
-      paymentIntentId,
-    });
+  /** Confirm payment for authenticated user (creates order from cart). Optional state/country for sales tax jurisdiction. */
+  async confirmPayment(paymentIntentId: string, state?: string, country?: string): Promise<Order> {
+    const body: { paymentIntentId: string; state?: string; country?: string } = { paymentIntentId };
+    if (state != null && state.trim()) body.state = state.trim();
+    if (country != null && country.trim()) body.country = country.trim();
+    const response = await this.api.post<ApiResponse<Order>>("/api/v1/payments/confirm", body);
     return response.data.data;
   }
 
@@ -307,8 +325,11 @@ class ApiService {
       ticketsSold: d.ticketsSold ?? 0,
       ticketsSoldTrendPercent: d.ticketsSoldTrendPercent ?? null,
       totalRevenue: toNum(d.totalRevenue),
+      platformFeesWithheld: toNum(d.platformFeesWithheld),
+      platformFeeRateLabel: d.platformFeeRateLabel ?? undefined,
       availableBalance: toNum(d.availableBalance),
       pendingBalance: toNum(d.pendingBalance),
+      pendingHoldDays: typeof d.pendingHoldDays === "number" ? d.pendingHoldDays : undefined,
       riskFlagged: Boolean(d.riskFlagged),
       riskLevel: d.riskLevel ?? "LOW",
       w9Submitted: Boolean(d.w9Submitted),
@@ -323,9 +344,32 @@ class ApiService {
     };
   }
 
+  /** Request a payout for the given amount. Validates balance and eligibility (verified, W-9 if $600+). */
+  async requestPayout(amount: number): Promise<{ id: string; amount: number; status: string }> {
+    const response = await this.api.post<ApiResponse<{ id: string; amount: number; status: string }>>(
+      "/api/v1/organizer/payouts/request",
+      { amount: Number(amount.toFixed(2)) }
+    );
+    return response.data.data;
+  }
+
   async getOrganizerTaxForms(): Promise<TaxFormEntry[]> {
     const response = await this.api.get<ApiResponse<TaxFormEntry[]>>("/api/v1/organizer/tax-forms");
     return response.data.data ?? [];
+  }
+
+  /** Download 1099-K PDF for a tax year. Triggers browser download. */
+  async downloadOrganizerTaxFormPdf(year: number): Promise<void> {
+    const response = await this.api.get<Blob>(`/api/v1/organizer/tax-forms/${year}/download`, {
+      responseType: "blob",
+    });
+    const blob = response.data;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `1099-K-${year}.pdf`;
+    a.click();
+    URL.revokeObjectURL(url);
   }
 
   async submitW9(data: SubmitW9RequestType): Promise<void> {

--- a/eventpro-frontend/src/lib/api.ts
+++ b/eventpro-frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from "axios";
 import type {
   ApiResponse,
+  PageResponse,
   ApiKey,
   User,
   Event,
@@ -27,15 +28,23 @@ import type {
   TeamMember,
   SeatResponse,
   CreateSeatMapRequest,
+  AdminStats,
+  EventSales,
+  RevenueData,
+  PendingVerification,
+  RecordSubscriptionPaymentRequest,
 } from "@/types/api";
 
 class ApiService {
   private api: AxiosInstance;
 
   constructor() {
-    // Default to localhost for development - set VITE_API_BASE_URL in production
+    // In dev always use same-origin so Vite proxy forwards /api to backend (avoids direct :8080 and CORS).
+    const baseURL = import.meta.env.DEV
+      ? ""
+      : (import.meta.env.VITE_API_BASE_URL || "http://localhost:8080");
     this.api = axios.create({
-      baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:8080",
+      baseURL,
       headers: {
         "Content-Type": "application/json",
       },
@@ -75,7 +84,35 @@ class ApiService {
     return response.data.data;
   }
 
-  /** Upgrade subscription tier (Basic → Pro or Enterprise). Returns updated user. */
+  /** Create Stripe Checkout Session for subscription. Redirect user to returned url. After payment, webhooks update tier. */
+  async createSubscriptionCheckoutSession(params: {
+    tier: "PRO" | "ENTERPRISE";
+    period?: "MONTHLY" | "YEARLY";
+    successUrl: string;
+    cancelUrl: string;
+  }): Promise<{ url: string }> {
+    const response = await this.api.post<ApiResponse<{ url: string }>>(
+      "/api/v1/subscription/create-checkout-session",
+      {
+        tier: params.tier,
+        period: params.period ?? "MONTHLY",
+        successUrl: params.successUrl,
+        cancelUrl: params.cancelUrl,
+      }
+    );
+    return response.data.data ?? { url: "" };
+  }
+
+  /** Sync subscription from Stripe (updates tier + role). Returns user and server message (e.g. why nothing changed). */
+  async syncSubscriptionFromStripe(): Promise<{ user: User; message: string }> {
+    const response = await this.api.post<ApiResponse<User>>("/api/v1/subscription/sync");
+    return {
+      user: response.data.data!,
+      message: response.data.message ?? "Done",
+    };
+  }
+
+  /** Upgrade subscription tier without payment (legacy / dev). Prefer createSubscriptionCheckoutSession for real billing. */
   async upgradeSubscription(tier: "PRO" | "ENTERPRISE"): Promise<User> {
     const response = await this.api.put<ApiResponse<User>>("/api/v1/users/me/subscription-tier", { tier });
     return response.data.data;
@@ -297,20 +334,131 @@ class ApiService {
     return response.data.data;
   }
 
-  // Admin endpoints
+  // Admin endpoints (only call from admin-only UI; backend enforces ADMIN role)
+  async getUsersPage(page = 1, size = 10): Promise<PageResponse<User>> {
+    const response = await this.api.get<ApiResponse<PageResponse<User>>>(
+      "/api/v1/admin/users",
+      { params: { page, size } }
+    );
+    const raw = response.data.data;
+    if (!raw) return { content: [], totalElements: 0, totalPages: 0, size, number: page - 1 };
+    return {
+      content: Array.isArray(raw) ? raw : (raw.content ?? []),
+      totalElements: raw.totalElements ?? raw.content?.length ?? 0,
+      totalPages: raw.totalPages ?? 1,
+      size: raw.size ?? size,
+      number: raw.number ?? page - 1,
+      first: raw.first,
+      last: raw.last,
+    };
+  }
+
   async getAllUsers(): Promise<User[]> {
-    const response = await this.api.get<ApiResponse<User[]>>("/api/v1/admin/users");
+    const page = await this.getUsersPage(1, 100);
+    return page.content;
+  }
+
+  /** Create a new user with ADMIN role. Requires caller to be ADMIN. */
+  async createAdminUser(body: {
+    email: string;
+    password: string;
+    firstName: string;
+    lastName: string;
+    phoneNumber?: string;
+  }): Promise<User> {
+    const response = await this.api.post<ApiResponse<User>>("/api/v1/admin/users", body);
     return response.data.data;
   }
 
   async updateUserRole(userId: string, role: string): Promise<User> {
-    const response = await this.api.put<ApiResponse<User>>(`/api/v1/admin/users/${userId}/role`, { role });
+    const response = await this.api.patch<ApiResponse<User>>(`/api/v1/admin/users/${userId}/role`, { role });
     return response.data.data;
   }
 
   async updateUserStatus(userId: string, status: string): Promise<User> {
-    const response = await this.api.put<ApiResponse<User>>(`/api/v1/admin/users/${userId}/status`, { status });
+    const response = await this.api.patch<ApiResponse<User>>(`/api/v1/admin/users/${userId}/status`, { status });
     return response.data.data;
+  }
+
+  async getStats(): Promise<AdminStats> {
+    const response = await this.api.get<ApiResponse<AdminStats>>("/api/v1/admin/stats");
+    const d = response.data.data;
+    const num = (v: unknown) => (typeof v === "number" && !Number.isNaN(v) ? v : typeof v === "string" ? parseFloat(v) || 0 : 0);
+    return {
+      totalUsers: Number(d?.totalUsers ?? 0),
+      totalEvents: Number(d?.totalEvents ?? 0),
+      totalTicketsSold: Number(d?.totalTicketsSold ?? 0),
+      totalRevenue: num(d?.totalRevenue),
+      userGrowth: num(d?.userGrowth),
+      eventGrowth: num(d?.eventGrowth),
+      ticketGrowth: num(d?.ticketGrowth),
+      revenueGrowth: num(d?.revenueGrowth),
+    };
+  }
+
+  async getVerificationPending(limit = 50): Promise<PendingVerification[]> {
+    const response = await this.api.get<ApiResponse<PendingVerification[]>>("/api/v1/admin/verification-pending", {
+      params: { limit },
+    });
+    return response.data.data ?? [];
+  }
+
+  async approveVerification(submissionId: string): Promise<void> {
+    await this.api.post(`/api/v1/admin/verification/${submissionId}/approve`);
+  }
+
+  async rejectVerification(submissionId: string, reason?: string): Promise<void> {
+    await this.api.post(`/api/v1/admin/verification/${submissionId}/reject`, reason != null ? { reason } : {});
+  }
+
+  async getEventSales(): Promise<EventSales[]> {
+    const response = await this.api.get<ApiResponse<EventSales[]>>("/api/v1/admin/event-sales");
+    const list = response.data.data ?? [];
+    return list.map((e: Record<string, unknown>) => ({
+      eventId: String(e.eventId ?? ""),
+      eventName: String(e.eventName ?? ""),
+      ticketsSold: Number(e.ticketsSold ?? 0),
+      revenue: Number(e.revenue ?? 0),
+      availableTickets: Number(e.availableTickets ?? 0),
+      totalTickets: Number(e.totalTickets ?? 0),
+    }));
+  }
+
+  async getRevenue(period = "30d"): Promise<RevenueData[]> {
+    const response = await this.api.get<ApiResponse<RevenueData[]>>("/api/v1/admin/revenue", { params: { period } });
+    const list = response.data.data ?? [];
+    return list.map((r: Record<string, unknown>) => ({
+      date: String(r.date ?? ""),
+      revenue: Number(r.revenue ?? 0),
+      ticketsSold: Number(r.ticketsSold ?? 0),
+    }));
+  }
+
+  async getEventsPage(page = 1, size = 10): Promise<PageResponse<Event>> {
+    const response = await this.api.get<ApiResponse<PageResponse<Event>>>("/api/v1/admin/events", {
+      params: { page, size },
+    });
+    const raw = response.data.data;
+    if (!raw) return { content: [], totalElements: 0, totalPages: 0, size, number: page - 1 };
+    return {
+      content: Array.isArray(raw) ? raw : (raw.content ?? []),
+      totalElements: raw.totalElements ?? raw.content?.length ?? 0,
+      totalPages: raw.totalPages ?? 1,
+      size: raw.size ?? size,
+      number: raw.number ?? page - 1,
+      first: raw.first,
+      last: raw.last,
+    };
+  }
+
+  async updateEventStatus(eventId: string, status: string): Promise<Event> {
+    const response = await this.api.patch<ApiResponse<Event>>(`/api/v1/admin/events/${eventId}/status`, { status });
+    return response.data.data;
+  }
+
+  async recordSubscriptionPayment(body: RecordSubscriptionPaymentRequest): Promise<{ id: string }> {
+    const response = await this.api.post<ApiResponse<{ id: string }>>("/api/v1/admin/subscription-payments", body);
+    return response.data.data ?? { id: "" };
   }
 
   // Organizer endpoints

--- a/eventpro-frontend/src/pages/Admin.tsx
+++ b/eventpro-frontend/src/pages/Admin.tsx
@@ -1,6 +1,15 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
-import { Shield, Users, Calendar, DollarSign } from "lucide-react";
+import {
+  Shield,
+  Users,
+  Calendar,
+  DollarSign,
+  BarChart3,
+  ShieldCheck,
+  TrendingUp,
+  CreditCard,
+} from "lucide-react";
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
 
@@ -9,63 +18,91 @@ const Admin = () => {
 
   const adminCards = [
     {
+      title: "Overview",
+      description: "Platform stats: users, events, tickets, revenue",
+      icon: BarChart3,
+      href: "/admin/overview",
+    },
+    {
       title: "User Management",
-      description: "Manage users, roles, and permissions",
+      description: "Manage users, roles, permissions, create admins",
       icon: Users,
       href: "/admin/users",
     },
     {
-      title: "Events Overview",
-      description: "View and manage all events",
+      title: "Verification (KYC)",
+      description: "Review and approve or reject identity verification",
+      icon: ShieldCheck,
+      href: "/admin/verification",
+    },
+    {
+      title: "Events",
+      description: "View all events on the platform",
       icon: Calendar,
-      href: "/events",
+      href: "/admin/events",
+    },
+    {
+      title: "Event Sales",
+      description: "Tickets sold and revenue per event",
+      icon: TrendingUp,
+      href: "/admin/event-sales",
+    },
+    {
+      title: "Revenue",
+      description: "Revenue and tickets sold over time",
+      icon: DollarSign,
+      href: "/admin/revenue",
+    },
+    {
+      title: "Record offline subscription",
+      description: "Record invoice/wire subscription payment (Stripe subscriptions are automatic)",
+      icon: CreditCard,
+      href: "/admin/subscription-payments",
     },
   ];
 
   return (
-    <div className="min-h-screen py-8">
-      <div className="container mx-auto px-4">
-        <div className="flex items-center gap-3 mb-8">
-          <div className="h-12 w-12 rounded-lg bg-gradient-primary flex items-center justify-center">
-            <Shield className="h-7 w-7 text-primary-foreground" />
-          </div>
-          <div>
-            <h1 className="text-4xl font-bold bg-gradient-primary bg-clip-text text-transparent">
-              Admin Dashboard
-            </h1>
-            <p className="text-muted-foreground">Welcome, {user?.firstName}</p>
-          </div>
+    <>
+      <div className="flex items-center gap-3 mb-8">
+        <div className="h-12 w-12 rounded-lg bg-gradient-primary flex items-center justify-center">
+          <Shield className="h-7 w-7 text-primary-foreground" />
         </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {adminCards.map((card, index) => {
-            const Icon = card.icon;
-            return (
-              <motion.div
-                key={card.title}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-              >
-                <Link to={card.href}>
-                  <Card className="h-full hover:shadow-lg transition-shadow cursor-pointer hover:border-primary/50">
-                    <CardHeader>
-                      <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center mb-4">
-                        <Icon className="h-6 w-6 text-primary" />
-                      </div>
-                      <CardTitle>{card.title}</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-muted-foreground">{card.description}</p>
-                    </CardContent>
-                  </Card>
-                </Link>
-              </motion.div>
-            );
-          })}
+        <div>
+          <h1 className="text-4xl font-bold bg-gradient-primary bg-clip-text text-transparent">
+            Admin Dashboard
+          </h1>
+          <p className="text-muted-foreground">Welcome, {user?.firstName}</p>
         </div>
       </div>
-    </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {adminCards.map((card, index) => {
+          const Icon = card.icon;
+          return (
+            <motion.div
+              key={card.title}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <Link to={card.href}>
+                <Card className="h-full hover:shadow-lg transition-shadow cursor-pointer hover:border-primary/50">
+                  <CardHeader>
+                    <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center mb-4">
+                      <Icon className="h-6 w-6 text-primary" />
+                    </div>
+                    <CardTitle>{card.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-muted-foreground">{card.description}</p>
+                  </CardContent>
+                </Card>
+              </Link>
+            </motion.div>
+          );
+        })}
+      </div>
+    </>
   );
 };
 

--- a/eventpro-frontend/src/pages/AdminDashboard.tsx
+++ b/eventpro-frontend/src/pages/AdminDashboard.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { BarChart3, Users, Calendar, Ticket, DollarSign, Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+import type { AdminStats } from "@/types/api";
+
+const StatCard = ({
+  title,
+  value,
+  sub,
+  icon: Icon,
+}: {
+  title: string;
+  value: string | number;
+  sub?: string;
+  icon: React.ElementType;
+}) => (
+  <Card>
+    <CardHeader className="flex flex-row items-center justify-between pb-2">
+      <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+      <Icon className="h-4 w-4 text-muted-foreground" />
+    </CardHeader>
+    <CardContent>
+      <div className="text-2xl font-bold">{value}</div>
+      {sub != null && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
+    </CardContent>
+  </Card>
+);
+
+const AdminDashboard = () => {
+  const adminApi = useAdminApi();
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!adminApi) return;
+    adminApi
+      .getStats()
+      .then(setStats)
+      .catch(() => setStats(null))
+      .finally(() => setLoading(false));
+  }, [adminApi]);
+
+  if (!adminApi) return null;
+
+  const formatGrowth = (n: number) =>
+    n == null || Number.isNaN(n) ? "—" : `${n >= 0 ? "+" : ""}${n.toFixed(1)}%`;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+          <BarChart3 className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold">Platform overview</h1>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-12 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          Loading stats…
+        </div>
+      ) : stats ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            title="Total users"
+            value={stats.totalUsers.toLocaleString()}
+            sub={formatGrowth(stats.userGrowth)}
+            icon={Users}
+          />
+          <StatCard
+            title="Total events"
+            value={stats.totalEvents.toLocaleString()}
+            sub={formatGrowth(stats.eventGrowth)}
+            icon={Calendar}
+          />
+          <StatCard
+            title="Tickets sold"
+            value={stats.totalTicketsSold.toLocaleString()}
+            sub={formatGrowth(stats.ticketGrowth)}
+            icon={Ticket}
+          />
+          <StatCard
+            title="Total revenue"
+            value={`$${stats.totalRevenue.toLocaleString(undefined, { minimumFractionDigits: 2 })}`}
+            sub={formatGrowth(stats.revenueGrowth)}
+            icon={DollarSign}
+          />
+        </div>
+      ) : (
+        <p className="text-muted-foreground py-8">Failed to load stats.</p>
+      )}
+    </motion.div>
+  );
+};
+
+export default AdminDashboard;

--- a/eventpro-frontend/src/pages/AdminEventSales.tsx
+++ b/eventpro-frontend/src/pages/AdminEventSales.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { useToast } from "@/hooks/use-toast";
+import { TrendingUp, Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+import type { EventSales } from "@/types/api";
+
+const AdminEventSales = () => {
+  const adminApi = useAdminApi();
+  const { toast } = useToast();
+  const [sales, setSales] = useState<EventSales[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!adminApi) return;
+    adminApi
+      .getEventSales()
+      .then(setSales)
+      .catch(() => {
+        toast({ title: "Failed to load event sales", variant: "destructive" });
+        setSales([]);
+      })
+      .finally(() => setLoading(false));
+  }, [adminApi, toast]);
+
+  if (!adminApi) return null;
+
+  const totalRevenue = sales.reduce((s, e) => s + (e.revenue ?? 0), 0);
+  const totalTickets = sales.reduce((s, e) => s + (e.ticketsSold ?? 0), 0);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+          <TrendingUp className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold">Event sales</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Sales by event</CardTitle>
+          <CardDescription>
+            Tickets sold and revenue per event.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading…
+            </div>
+          ) : sales.length === 0 ? (
+            <p className="text-muted-foreground py-8">No event sales data.</p>
+          ) : (
+            <>
+              <div className="flex gap-4 mb-4 text-sm">
+                <span className="text-muted-foreground">
+                  Total revenue: <strong>${totalRevenue.toLocaleString(undefined, { minimumFractionDigits: 2 })}</strong>
+                </span>
+                <span className="text-muted-foreground">
+                  Total tickets: <strong>{totalTickets.toLocaleString()}</strong>
+                </span>
+              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Event</TableHead>
+                    <TableHead className="text-right">Tickets sold</TableHead>
+                    <TableHead className="text-right">Available</TableHead>
+                    <TableHead className="text-right">Total capacity</TableHead>
+                    <TableHead className="text-right">Revenue</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sales.map((e) => (
+                    <TableRow key={e.eventId}>
+                      <TableCell className="font-medium">{e.eventName || "—"}</TableCell>
+                      <TableCell className="text-right">{e.ticketsSold?.toLocaleString() ?? "—"}</TableCell>
+                      <TableCell className="text-right">{e.availableTickets?.toLocaleString() ?? "—"}</TableCell>
+                      <TableCell className="text-right">{e.totalTickets?.toLocaleString() ?? "—"}</TableCell>
+                      <TableCell className="text-right">
+                        ${(e.revenue ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default AdminEventSales;

--- a/eventpro-frontend/src/pages/AdminEvents.tsx
+++ b/eventpro-frontend/src/pages/AdminEvents.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { useToast } from "@/hooks/use-toast";
+import { Calendar, Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+import type { Event } from "@/types/api";
+
+const AdminEvents = () => {
+  const adminApi = useAdminApi();
+  const { toast } = useToast();
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  useEffect(() => {
+    if (!adminApi) return;
+    setLoading(true);
+    adminApi
+      .getEventsPage(page, 10)
+      .then((p) => {
+        setEvents(p.content);
+        setTotalPages(p.totalPages);
+      })
+      .catch(() => {
+        toast({ title: "Failed to load events", variant: "destructive" });
+        setEvents([]);
+      })
+      .finally(() => setLoading(false));
+  }, [adminApi, page, toast]);
+
+  if (!adminApi) return null;
+
+  const formatDate = (s: string | undefined) => {
+    if (!s) return "—";
+    try {
+      return new Date(s).toLocaleDateString(undefined, {
+        dateStyle: "short",
+        timeStyle: "short",
+      });
+    } catch {
+      return s;
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+          <Calendar className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold">All events</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Events</CardTitle>
+          <CardDescription>Platform events (read-only list).</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading…
+            </div>
+          ) : events.length === 0 ? (
+            <p className="text-muted-foreground py-8">No events.</p>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Start</TableHead>
+                    <TableHead>Organizer</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {events.map((e) => (
+                    <TableRow key={e.id}>
+                      <TableCell className="font-medium">{e.name || e.title || "—"}</TableCell>
+                      <TableCell>{formatDate(e.startTime)}</TableCell>
+                      <TableCell>{e.organizerId ?? "—"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between mt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page <= 1}
+                  >
+                    Previous
+                  </Button>
+                  <span className="text-sm text-muted-foreground">
+                    Page {page} of {totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={page >= totalPages}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default AdminEvents;

--- a/eventpro-frontend/src/pages/AdminRevenue.tsx
+++ b/eventpro-frontend/src/pages/AdminRevenue.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { useToast } from "@/hooks/use-toast";
+import { DollarSign, Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+import type { RevenueData } from "@/types/api";
+
+const PERIODS = [
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "90d", label: "Last 90 days" },
+];
+
+const AdminRevenue = () => {
+  const adminApi = useAdminApi();
+  const { toast } = useToast();
+  const [data, setData] = useState<RevenueData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState("30d");
+
+  useEffect(() => {
+    if (!adminApi) return;
+    setLoading(true);
+    adminApi
+      .getRevenue(period)
+      .then(setData)
+      .catch(() => {
+        toast({ title: "Failed to load revenue", variant: "destructive" });
+        setData([]);
+      })
+      .finally(() => setLoading(false));
+  }, [adminApi, period, toast]);
+
+  if (!adminApi) return null;
+
+  const totalRevenue = data.reduce((s, r) => s + (r.revenue ?? 0), 0);
+  const totalTickets = data.reduce((s, r) => s + (r.ticketsSold ?? 0), 0);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+          <DollarSign className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold">Revenue</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <CardTitle>Revenue over time</CardTitle>
+              <CardDescription>Revenue and tickets sold by date.</CardDescription>
+            </div>
+            <select
+              className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={period}
+              onChange={(e) => setPeriod(e.target.value)}
+            >
+              {PERIODS.map((p) => (
+                <option key={p.value} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading…
+            </div>
+          ) : data.length === 0 ? (
+            <p className="text-muted-foreground py-8">No revenue data for this period.</p>
+          ) : (
+            <>
+              <div className="flex gap-4 mb-4 text-sm">
+                <span className="text-muted-foreground">
+                  Total: <strong>${totalRevenue.toLocaleString(undefined, { minimumFractionDigits: 2 })}</strong>
+                </span>
+                <span className="text-muted-foreground">
+                  Tickets: <strong>{totalTickets.toLocaleString()}</strong>
+                </span>
+              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead className="text-right">Revenue</TableHead>
+                    <TableHead className="text-right">Tickets sold</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {[...data].reverse().map((r, i) => (
+                    <TableRow key={r.date ?? i}>
+                      <TableCell>{r.date ?? "—"}</TableCell>
+                      <TableCell className="text-right">
+                        ${(r.revenue ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                      </TableCell>
+                      <TableCell className="text-right">{r.ticketsSold?.toLocaleString() ?? "—"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default AdminRevenue;

--- a/eventpro-frontend/src/pages/AdminSubscriptionPayments.tsx
+++ b/eventpro-frontend/src/pages/AdminSubscriptionPayments.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { useToast } from "@/hooks/use-toast";
+import { CreditCard, Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+
+const AdminSubscriptionPayments = () => {
+  const adminApi = useAdminApi();
+  const { toast } = useToast();
+  const [userId, setUserId] = useState("");
+  const [amount, setAmount] = useState("");
+  const [tier, setTier] = useState<"PRO" | "ENTERPRISE">("PRO");
+  const [period, setPeriod] = useState<"MONTHLY" | "YEARLY">("MONTHLY");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!adminApi) return;
+    const amt = parseFloat(amount);
+    if (!userId.trim() || Number.isNaN(amt) || amt < 0) {
+      toast({ title: "Enter a valid user ID and amount", variant: "destructive" });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await adminApi.recordSubscriptionPayment({
+        userId: userId.trim(),
+        amount: amt,
+        tier,
+        period,
+      });
+      toast({ title: "Subscription payment recorded" });
+      setAmount("");
+    } catch {
+      toast({ title: "Failed to record payment", variant: "destructive" });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!adminApi) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+          <CreditCard className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold">Record offline subscription payment</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Record offline payment</CardTitle>
+          <CardDescription>
+            For invoice, wire, or manual grants only. Normal subscriptions are recorded automatically via Stripe when users upgrade on the Pricing page.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="max-w-md space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="sub-userId">User ID (UUID)</Label>
+              <Input
+                id="sub-userId"
+                placeholder="e.g. 550e8400-e29b-41d4-a716-446655440000"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sub-amount">Amount ($)</Label>
+              <Input
+                id="sub-amount"
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="0.00"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Tier</Label>
+              <select
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={tier}
+                onChange={(e) => setTier(e.target.value as "PRO" | "ENTERPRISE")}
+              >
+                <option value="PRO">Pro</option>
+                <option value="ENTERPRISE">Enterprise</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label>Period</Label>
+              <select
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={period}
+                onChange={(e) => setPeriod(e.target.value as "MONTHLY" | "YEARLY")}
+              >
+                <option value="MONTHLY">Monthly</option>
+                <option value="YEARLY">Yearly</option>
+              </select>
+            </div>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Recording…
+                </>
+              ) : (
+                "Record payment"
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default AdminSubscriptionPayments;

--- a/eventpro-frontend/src/pages/AdminVerification.tsx
+++ b/eventpro-frontend/src/pages/AdminVerification.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { useToast } from "@/hooks/use-toast";
+import { ShieldCheck, Loader2, Check, X } from "lucide-react";
+import { motion } from "framer-motion";
+import type { PendingVerification } from "@/types/api";
+
+const AdminVerification = () => {
+  const adminApi = useAdminApi();
+  const { toast } = useToast();
+  const [list, setList] = useState<PendingVerification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actingId, setActingId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState<Record<string, string>>({});
+
+  const fetchPending = () => {
+    if (!adminApi) return;
+    setLoading(true);
+    adminApi
+      .getVerificationPending(50)
+      .then(setList)
+      .catch(() => {
+        toast({ title: "Failed to load pending verifications", variant: "destructive" });
+        setList([]);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchPending();
+  }, [adminApi]);
+
+  const handleApprove = async (submissionId: string) => {
+    if (!adminApi) return;
+    setActingId(submissionId);
+    try {
+      await adminApi.approveVerification(submissionId);
+      setList((prev) => prev.filter((s) => s.id !== submissionId));
+      toast({ title: "Verification approved" });
+    } catch {
+      toast({ title: "Failed to approve", variant: "destructive" });
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleReject = async (submissionId: string) => {
+    if (!adminApi) return;
+    setActingId(submissionId);
+    try {
+      await adminApi.rejectVerification(submissionId, rejectReason[submissionId] || undefined);
+      setList((prev) => prev.filter((s) => s.id !== submissionId));
+      setRejectReason((prev) => ({ ...prev, [submissionId]: "" }));
+      toast({ title: "Verification rejected" });
+    } catch {
+      toast({ title: "Failed to reject", variant: "destructive" });
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  if (!adminApi) return null;
+
+  const formatDate = (s: string) => {
+    try {
+      return new Date(s).toLocaleString();
+    } catch {
+      return s;
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+          <ShieldCheck className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold">Verification (KYC)</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Pending submissions</CardTitle>
+          <CardDescription>
+            Review and approve or reject identity verification requests.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading…
+            </div>
+          ) : list.length === 0 ? (
+            <p className="text-muted-foreground py-8">No pending verifications.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Entity</TableHead>
+                  <TableHead>Location</TableHead>
+                  <TableHead>Submitted</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {list.map((s) => {
+                  const busy = actingId === s.id;
+                  return (
+                    <TableRow key={s.id}>
+                      <TableCell>{s.email}</TableCell>
+                      <TableCell>{s.legalEntityType || "—"}</TableCell>
+                      <TableCell>{[s.addressCity, s.addressState].filter(Boolean).join(", ") || "—"}</TableCell>
+                      <TableCell>{formatDate(s.submittedAt)}</TableCell>
+                      <TableCell className="text-right space-y-2">
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          <Input
+                            placeholder="Rejection reason (optional)"
+                            className="max-w-[200px] h-8 text-sm"
+                            value={rejectReason[s.id] ?? ""}
+                            onChange={(e) =>
+                              setRejectReason((prev) => ({ ...prev, [s.id]: e.target.value }))
+                            }
+                          />
+                          <Button
+                            size="sm"
+                            variant="default"
+                            onClick={() => handleApprove(s.id)}
+                            disabled={busy}
+                          >
+                            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                            Approve
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => handleReject(s.id)}
+                            disabled={busy}
+                          >
+                            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <X className="h-4 w-4" />}
+                            Reject
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default AdminVerification;

--- a/eventpro-frontend/src/pages/Checkout.tsx
+++ b/eventpro-frontend/src/pages/Checkout.tsx
@@ -39,6 +39,23 @@ function eventAddonsToMerchandise(addons: { id: string; name: string; descriptio
   }));
 }
 
+/** US states for sales tax jurisdiction dropdown (code + name). */
+const US_STATE_OPTIONS: { code: string; name: string }[] = [
+  { code: "AL", name: "Alabama" }, { code: "AK", name: "Alaska" }, { code: "AZ", name: "Arizona" }, { code: "AR", name: "Arkansas" },
+  { code: "CA", name: "California" }, { code: "CO", name: "Colorado" }, { code: "CT", name: "Connecticut" }, { code: "DE", name: "Delaware" },
+  { code: "FL", name: "Florida" }, { code: "GA", name: "Georgia" }, { code: "HI", name: "Hawaii" }, { code: "ID", name: "Idaho" },
+  { code: "IL", name: "Illinois" }, { code: "IN", name: "Indiana" }, { code: "IA", name: "Iowa" }, { code: "KS", name: "Kansas" },
+  { code: "KY", name: "Kentucky" }, { code: "LA", name: "Louisiana" }, { code: "ME", name: "Maine" }, { code: "MD", name: "Maryland" },
+  { code: "MA", name: "Massachusetts" }, { code: "MI", name: "Michigan" }, { code: "MN", name: "Minnesota" }, { code: "MS", name: "Mississippi" },
+  { code: "MO", name: "Missouri" }, { code: "MT", name: "Montana" }, { code: "NE", name: "Nebraska" }, { code: "NV", name: "Nevada" },
+  { code: "NH", name: "New Hampshire" }, { code: "NJ", name: "New Jersey" }, { code: "NM", name: "New Mexico" }, { code: "NY", name: "New York" },
+  { code: "NC", name: "North Carolina" }, { code: "ND", name: "North Dakota" }, { code: "OH", name: "Ohio" }, { code: "OK", name: "Oklahoma" },
+  { code: "OR", name: "Oregon" }, { code: "PA", name: "Pennsylvania" }, { code: "RI", name: "Rhode Island" }, { code: "SC", name: "South Carolina" },
+  { code: "SD", name: "South Dakota" }, { code: "TN", name: "Tennessee" }, { code: "TX", name: "Texas" }, { code: "UT", name: "Utah" },
+  { code: "VT", name: "Vermont" }, { code: "VA", name: "Virginia" }, { code: "WA", name: "Washington" }, { code: "WV", name: "West Virginia" },
+  { code: "WI", name: "Wisconsin" }, { code: "WY", name: "Wyoming" }, { code: "DC", name: "District of Columbia" },
+];
+
 const Checkout = () => {
   const { items, totalAmount, removeItem, clearCart } = useCart();
   const { user, isAuthenticated } = useAuth();
@@ -69,8 +86,31 @@ const Checkout = () => {
   const [successTicketType, setSuccessTicketType] = useState<string>("");
   /** Live form values for ticket preview (guest only, before submit). */
   const [previewGuest, setPreviewGuest] = useState({ firstName: "", lastName: "", email: "" });
+  /** Checkout totals including tax (from GET /payments/checkout-totals). Use total for payment intent when tax enabled. */
+  const [checkoutTotals, setCheckoutTotals] = useState<{ subtotal: number; taxRatePercent: number; tax: number; total: number } | null>(null);
+  /** Buyer state/country for jurisdiction-based sales tax (e.g. state=CA, country=US). */
+  const [taxState, setTaxState] = useState<string>("");
+  const [taxCountry, setTaxCountry] = useState<string>("US");
 
   const eventIds = useMemo(() => [...new Set(items.map((i) => i.eventId).filter(Boolean))], [items]);
+
+  const merchTotal = selectedMerch.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
+  const grandTotal = totalAmount + merchTotal + (donationAmount || 0);
+
+  // Fetch checkout totals (subtotal + tax) when grandTotal and optional state/country change
+  useEffect(() => {
+    if (grandTotal <= 0) {
+      setCheckoutTotals(null);
+      return;
+    }
+    apiService
+      .getCheckoutTotals(grandTotal, taxState || undefined, taxCountry || undefined)
+      .then(setCheckoutTotals)
+      .catch(() => setCheckoutTotals(null));
+  }, [grandTotal, taxState, taxCountry]);
 
   useEffect(() => {
     if (eventIds.length === 0) {
@@ -100,12 +140,6 @@ const Checkout = () => {
       })
       .catch(() => {});
   }, [isAuthenticated, items.length]);
-
-  const merchTotal = selectedMerch.reduce(
-    (sum, item) => sum + item.price * item.quantity,
-    0
-  );
-  const grandTotal = totalAmount + merchTotal + (donationAmount || 0);
 
   /** Attendee name for ticket preview: from user, guestInfo, or live preview. */
   const attendeeName =
@@ -143,7 +177,8 @@ const Checkout = () => {
     setReservedTicketIds(null);
     if (!isAuthenticated) setReservedUntil(null);
     try {
-      const amount = Number(grandTotal.toFixed(2));
+      const amountToCharge = checkoutTotals?.total ?? grandTotal;
+      const amount = Number(amountToCharge.toFixed(2));
       if (amount <= 0) {
         setPaymentError("Order total must be greater than 0");
         toast.error("Order total must be greater than 0");
@@ -185,6 +220,7 @@ const Checkout = () => {
 
   const buildGuestConfirm = (paymentIntentId: string) => {
     if (!guestInfo) throw new Error("Guest info required");
+    const totalToConfirm = checkoutTotals?.total ?? grandTotal;
     return apiService.confirmGuestPayment({
       paymentIntentId,
       email: guestInfo.email,
@@ -195,12 +231,15 @@ const Checkout = () => {
         ticketType: i.ticketTypeId,
         quantity: i.quantity,
       })),
-      totalAmount: grandTotal,
+      totalAmount: totalToConfirm,
       donationAmount: donationAmount > 0 ? Number(donationAmount.toFixed(2)) : undefined,
       reservedTicketIds: reservedTicketIds ?? undefined,
       howDidYouHear: howDidYouHear && howDidYouHear !== "__" ? howDidYouHear : undefined,
       receiveTicketViaWhatsApp: receiveTicketViaWhatsApp || undefined,
       receiveTicketViaSMS: receiveTicketViaSMS || undefined,
+      state: taxState?.trim() || undefined,
+      country: taxCountry?.trim() || undefined,
+      taxAmount: checkoutTotals && checkoutTotals.tax > 0 ? Number(checkoutTotals.tax.toFixed(2)) : undefined,
     });
   };
 
@@ -295,9 +334,10 @@ const Checkout = () => {
                 amount={grandTotal}
                 isGuest={!isAuthenticated && !!guestInfo}
                 guestConfirm={!isAuthenticated && guestInfo ? buildGuestConfirm : undefined}
-                authenticatedConfirm={isAuthenticated ? (id) => apiService.confirmPayment(id) : undefined}
+                authenticatedConfirm={isAuthenticated ? (id) => apiService.confirmPayment(id, taxState?.trim() || undefined, taxCountry?.trim() || undefined) : undefined}
                 onSuccess={handlePaymentSuccess}
                 onError={(msg) => { setPaymentError(msg); toast.error(msg); }}
+                billingDetails={(taxState || taxCountry) ? { state: taxState?.trim() || undefined, country: taxCountry?.trim() || undefined } : undefined}
               />
               <Button
                 type="button"
@@ -622,6 +662,50 @@ const Checkout = () => {
                   </div>
                 )}
 
+                {/* Billing address: standard checkout field; we use state/country for tax (same as Stripe, TaxJar). */}
+                <div className="space-y-3 pt-2 border-t border-border">
+                  <div>
+                    <Label className="text-sm font-medium text-muted-foreground">
+                      Billing address
+                    </Label>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Used for your receipt and to calculate sales tax where required.
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label className="text-xs text-muted-foreground">Country</Label>
+                      <Select value={taxCountry || "US"} onValueChange={(v) => setTaxCountry(v || "US")}>
+                        <SelectTrigger className="rounded-lg border-primary/20 bg-background/80">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="US">United States</SelectItem>
+                          <SelectItem value="CA">Canada</SelectItem>
+                          <SelectItem value="GB">United Kingdom</SelectItem>
+                          <SelectItem value="OTHER">Other</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="text-xs text-muted-foreground">State / Province</Label>
+                      <Select value={taxState || "__"} onValueChange={(v) => setTaxState(v === "__" ? "" : v)}>
+                        <SelectTrigger className="rounded-lg border-primary/20 bg-background/80">
+                          <SelectValue placeholder="State" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__">Select state (optional)</SelectItem>
+                          {US_STATE_OPTIONS.map((s) => (
+                            <SelectItem key={s.code} value={s.code}>
+                              {s.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                </div>
+
                 <div className="border-t border-border pt-4 space-y-2">
                   <div className="flex justify-between text-sm">
                     <span>Tickets Subtotal</span>
@@ -639,10 +723,16 @@ const Checkout = () => {
                       <span>${donationAmount.toFixed(2)}</span>
                     </div>
                   )}
+                  {checkoutTotals && checkoutTotals.tax > 0 && (
+                    <div className="flex justify-between text-sm">
+                      <span>Tax ({checkoutTotals.taxRatePercent}%)</span>
+                      <span>${checkoutTotals.tax.toFixed(2)}</span>
+                    </div>
+                  )}
                   <div className="flex justify-between items-baseline pt-2 border-t">
                     <span className="text-sm font-medium text-muted-foreground uppercase tracking-wider">Total</span>
                     <span className="text-2xl sm:text-3xl font-bold tabular-nums tracking-tight text-foreground">
-                      ${grandTotal.toFixed(2)}
+                      ${(checkoutTotals?.total ?? grandTotal).toFixed(2)}
                     </span>
                   </div>
                 </div>

--- a/eventpro-frontend/src/pages/Pricing.tsx
+++ b/eventpro-frontend/src/pages/Pricing.tsx
@@ -17,7 +17,9 @@ import {
   Headphones,
   CreditCard,
   Shield,
-  Clock
+  Clock,
+  Loader2,
+  RefreshCw
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
@@ -29,14 +31,38 @@ const Pricing = () => {
   const { user, refreshUser } = useAuth();
   const navigate = useNavigate();
   const [upgradingTier, setUpgradingTier] = useState<string | null>(null);
+  const [syncingPlan, setSyncingPlan] = useState(false);
+
+  const handleRefreshPlan = async () => {
+    if (!user) return;
+    try {
+      setSyncingPlan(true);
+      const { message } = await apiService.syncSubscriptionFromStripe();
+      await refreshUser();
+      toast.info(message);
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message ?? "Could not refresh plan.";
+      toast.error(msg);
+    } finally {
+      setSyncingPlan(false);
+    }
+  };
 
   const handleUpgrade = async (tier: "PRO" | "ENTERPRISE") => {
     try {
       setUpgradingTier(tier);
-      await apiService.upgradeSubscription(tier);
-      await refreshUser();
-      toast.success(`You're now on ${tier}. New features are unlocked.`);
-      navigate("/organizer");
+      const base = typeof window !== "undefined" ? window.location.origin : "";
+      const { url } = await apiService.createSubscriptionCheckoutSession({
+        tier,
+        period: isAnnual ? "YEARLY" : "MONTHLY",
+        successUrl: `${base}/subscription/return`,
+        cancelUrl: `${base}/pricing`,
+      });
+      if (url) {
+        window.location.href = url;
+        return;
+      }
+      throw new Error("No checkout URL returned");
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message ?? "Upgrade failed";
       toast.error(msg);
@@ -50,6 +76,16 @@ const Pricing = () => {
     if (tierName === "Basic") return false;
     if (tierName === "Pro") return current === "BASIC";
     if (tierName === "Enterprise") return current === "BASIC" || current === "PRO";
+    return false;
+  };
+
+  /** True if the user is already on this tier or a higher one (so we show "Current plan" instead of trial/upgrade CTA). */
+  const isCurrentOrHigherTier = (tierName: string): boolean => {
+    if (!user) return false;
+    const current = (user.subscriptionTier ?? "BASIC").toUpperCase();
+    if (tierName === "Basic") return true;
+    if (tierName === "Pro") return current === "PRO" || current === "ENTERPRISE";
+    if (tierName === "Enterprise") return current === "ENTERPRISE";
     return false;
   };
 
@@ -211,6 +247,23 @@ const Pricing = () => {
               </Badge>
             </Label>
           </div>
+
+          {/* Refresh plan: only show for BASIC users who might have subscribed elsewhere or need to sync */}
+          {user && (user.subscriptionTier !== "PRO" && user.subscriptionTier !== "ENTERPRISE") && (
+            <div className="mt-6 flex flex-col items-center gap-1">
+              <p className="text-sm text-muted-foreground">Already subscribed or on trial?</p>
+              <Button
+                variant="outline"
+                size="default"
+                onClick={handleRefreshPlan}
+                disabled={syncingPlan}
+                className="gap-2"
+              >
+                {syncingPlan ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                Refresh my plan
+              </Button>
+            </div>
+          )}
         </div>
 
         {/* Pricing Cards */}
@@ -296,6 +349,10 @@ const Pricing = () => {
                       onClick={() => handleUpgrade(tier.name.toUpperCase() as "PRO" | "ENTERPRISE")}
                     >
                       {upgradingTier === tier.name ? "Upgrading…" : tier.name === "Pro" ? "Upgrade to Pro" : "Upgrade to Enterprise"}
+                    </Button>
+                  ) : tier.name !== "Basic" && user && isCurrentOrHigherTier(tier.name) ? (
+                    <Button className="w-full" variant="secondary" size="lg" disabled>
+                      Current plan
                     </Button>
                   ) : (
                     <Button 

--- a/eventpro-frontend/src/pages/Profile.tsx
+++ b/eventpro-frontend/src/pages/Profile.tsx
@@ -269,6 +269,7 @@ const Profile = () => {
   const riskLevel = user?.riskLevel ?? summary?.riskLevel ?? "LOW";
   const isHighRisk = riskLevel === "HIGH";
   const payoutBalance = summary?.availableBalance ?? 0;
+  const platformFeesWithheld = summary ? Number(summary.platformFeesWithheld ?? 0) : 0;
 
   const handleRecalculateRisk = useCallback(() => {
     if (!hasRole("ORGANIZER")) return;
@@ -636,8 +637,8 @@ const Profile = () => {
             </Card>
           )}
 
-          {/* Pro/Enterprise: White-Label / custom branding */}
-          {isProOrEnterprise && (
+          {/* Enterprise only: White-Label (per pricing page) */}
+          {isEnterprise && (
             <Card className="md:col-span-3 rounded-xl border-0 bg-white/70 dark:bg-white/10 backdrop-blur-[10px] shadow-md">
               <CardContent className="p-6">
                 <h2 className="text-lg font-bold flex items-center gap-2 mb-1">
@@ -796,10 +797,19 @@ const Profile = () => {
                   <span className="w-2 h-8 rounded-full bg-gradient-to-b from-primary to-primary-glow" />
                   Your Impact
                 </h2>
-                {/* Payout balance (real-time) */}
+                {/* Payout balance (after platform fees) */}
                 {!summaryLoading && (
                   <div className="mb-4 rounded-xl bg-white/80 dark:bg-white/10 px-4 py-3 border border-primary/10 flex items-center justify-between">
-                    <span className="text-sm font-medium text-muted-foreground">Available for payout</span>
+                    <div>
+                      <span className="text-sm font-medium text-muted-foreground">
+                        Available for payout{platformFeesWithheld > 0 ? " (after platform fees)" : ""}
+                      </span>
+                      {platformFeesWithheld > 0 && (
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                          Platform fees withheld: ${platformFeesWithheld.toFixed(2)}
+                        </p>
+                      )}
+                    </div>
                     <span className="text-xl font-bold text-foreground">
                       ${typeof payoutBalance === "number" ? payoutBalance.toFixed(2) : "0.00"}
                     </span>

--- a/eventpro-frontend/src/pages/Profile.tsx
+++ b/eventpro-frontend/src/pages/Profile.tsx
@@ -5,7 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/contexts/AuthContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   Mail,
   Calendar,
@@ -43,6 +43,7 @@ const VERIFIED_CELEBRATION_KEY = "profile_verified_celebration_shown";
 const Profile = () => {
   const { user, hasRole, refreshUser } = useAuth();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [summary, setSummary] = useState<OrganizerSummary | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [identityModalOpen, setIdentityModalOpen] = useState(false);
@@ -80,6 +81,28 @@ const Profile = () => {
   useEffect(() => {
     fetchSummary();
   }, [fetchSummary]);
+
+  // After returning from Stripe Checkout, sync subscription from Stripe so tier + role update (even if webhooks missed)
+  useEffect(() => {
+    if (searchParams.get("subscription") !== "success") return;
+    apiService
+      .syncSubscriptionFromStripe()
+      .then(({ message }) => {
+        refreshUser();
+        setSearchParams((prev) => {
+          prev.delete("subscription");
+          return prev;
+        });
+        if (message.toLowerCase().includes("synced") || message.toLowerCase().includes("tier=")) {
+          toast.success("Subscription updated. You now have organizer access.");
+        } else {
+          toast.info(message);
+        }
+      })
+      .catch(() => {
+        toast.error("Could not sync subscription. Your payment may still have gone through.");
+      });
+  }, [searchParams, refreshUser, setSearchParams]);
 
   const fetchApiKeys = useCallback(() => {
     if (user?.subscriptionTier !== "ENTERPRISE") return;

--- a/eventpro-frontend/src/pages/SubscriptionReturn.tsx
+++ b/eventpro-frontend/src/pages/SubscriptionReturn.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthContext";
+import { apiService } from "@/lib/api";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+/**
+ * Stripe redirects here after subscription checkout. We sync tier/role from Stripe
+ * and redirect to Profile so the user sees their updated plan without any extra click.
+ */
+const SubscriptionReturn = () => {
+  const { refreshUser } = useAuth();
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<"syncing" | "done" | "error">("syncing");
+
+  useEffect(() => {
+    let cancelled = false;
+    apiService
+      .syncSubscriptionFromStripe()
+      .then(({ message }) => {
+        if (cancelled) return;
+        setStatus("done");
+        refreshUser();
+        if (message.toLowerCase().includes("synced") || message.toLowerCase().includes("tier=")) {
+          toast.success("Subscription updated. You now have organizer access.");
+        } else {
+          toast.info(message);
+        }
+        navigate("/profile", { replace: true });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setStatus("error");
+        toast.error("Could not sync subscription. Your payment may still have gone through.");
+        navigate("/profile", { replace: true });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshUser, navigate]);
+
+  return (
+    <div className="min-h-[40vh] flex flex-col items-center justify-center gap-4 p-6">
+      {status === "syncing" && (
+        <>
+          <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
+          <p className="text-muted-foreground">Setting up your account…</p>
+        </>
+      )}
+      {status === "done" && (
+        <p className="text-muted-foreground">Redirecting to your profile…</p>
+      )}
+      {status === "error" && (
+        <p className="text-muted-foreground">Redirecting to your profile…</p>
+      )}
+    </div>
+  );
+};
+
+export default SubscriptionReturn;

--- a/eventpro-frontend/src/pages/UserManagement.tsx
+++ b/eventpro-frontend/src/pages/UserManagement.tsx
@@ -1,37 +1,306 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Users } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { useAuth } from "@/contexts/AuthContext";
+import { Users, Loader2, UserPlus } from "lucide-react";
 import { motion } from "framer-motion";
+import type { User, UserRole, UserStatus } from "@/types/api";
+import { useToast } from "@/hooks/use-toast";
+
+const createAdminSchema = z.object({
+  email: z.string().email("Invalid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  phoneNumber: z.string().optional(),
+});
+type CreateAdminFormData = z.infer<typeof createAdminSchema>;
 
 const UserManagement = () => {
-  return (
-    <div className="min-h-screen py-8">
-      <div className="container mx-auto px-4">
-        <div className="flex items-center gap-3 mb-8">
-          <div className="h-12 w-12 rounded-lg bg-gradient-primary flex items-center justify-center">
-            <Users className="h-7 w-7 text-primary-foreground" />
-          </div>
-          <h1 className="text-4xl font-bold bg-gradient-primary bg-clip-text text-transparent">
-            User Management
-          </h1>
-        </div>
+  const adminApi = useAdminApi();
+  const { user: currentUser } = useAuth();
+  const { toast } = useToast();
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [createSubmitting, setCreateSubmitting] = useState(false);
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
-          <Card>
-            <CardHeader>
-              <CardTitle>All Users</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">
-                User list will be loaded from your backend API.
-              </p>
-            </CardContent>
-          </Card>
-        </motion.div>
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreateAdminFormData>({
+    resolver: zodResolver(createAdminSchema),
+    defaultValues: { firstName: "", lastName: "", email: "", password: "", phoneNumber: "" },
+  });
+
+  useEffect(() => {
+    if (!adminApi) return;
+    let cancelled = false;
+    setLoading(true);
+    adminApi
+      .getUsersPage(1, 50)
+      .then((page) => {
+        if (!cancelled) setUsers(page.content);
+      })
+      .catch(() => {
+        if (!cancelled) toast({ title: "Failed to load users", variant: "destructive" });
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [adminApi, toast]);
+
+  const onCreateAdmin = async (data: CreateAdminFormData) => {
+    if (!adminApi) return;
+    setCreateSubmitting(true);
+    try {
+      const created = await adminApi.createAdminUser({
+        email: data.email.trim(),
+        password: data.password,
+        firstName: data.firstName.trim(),
+        lastName: data.lastName.trim(),
+        phoneNumber: data.phoneNumber?.trim() || undefined,
+      });
+      setUsers((prev) => [created, ...prev]);
+      reset();
+      toast({ title: "Admin user created" });
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === "object" && "response" in err
+          ? (err as { response?: { data?: { message?: string } } }).response?.data?.message
+          : null;
+      toast({
+        title: "Failed to create admin user",
+        description: message || "Email may already be in use.",
+        variant: "destructive",
+      });
+    } finally {
+      setCreateSubmitting(false);
+    }
+  };
+
+  const handleRoleChange = async (user: User, newRole: UserRole) => {
+    if (!adminApi || user.role === newRole) return;
+    if (user.id === currentUser?.id && newRole !== "ADMIN") {
+      toast({ title: "You cannot change your own role", variant: "destructive" });
+      return;
+    }
+    setUpdatingId(user.id);
+    try {
+      const updated = await adminApi.updateUserRole(user.id, newRole);
+      setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
+      toast({ title: "Role updated" });
+    } catch {
+      toast({ title: "Failed to update role", variant: "destructive" });
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const handleStatusChange = async (user: User, newStatus: UserStatus) => {
+    if (!adminApi || user.status === newStatus) return;
+    if (user.id === currentUser?.id) {
+      toast({ title: "You cannot change your own status", variant: "destructive" });
+      return;
+    }
+    setUpdatingId(user.id);
+    try {
+      const updated = await adminApi.updateUserStatus(user.id, newStatus);
+      setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
+      toast({ title: "Status updated" });
+    } catch {
+      toast({ title: "Failed to update status", variant: "destructive" });
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  if (!adminApi) {
+    return null;
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+          <Users className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold">User Management</h1>
       </div>
-    </div>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UserPlus className="h-5 w-5" />
+            Create admin user
+          </CardTitle>
+          <CardDescription>
+            Add a new user with ADMIN role. They will be able to access the admin dashboard and APIs.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onCreateAdmin)} className="grid gap-4 sm:grid-cols-2 lg:grid-cols-6 items-end">
+            <div className="space-y-2">
+              <Label htmlFor="create-email">Email</Label>
+              <Input
+                id="create-email"
+                type="email"
+                placeholder="admin@example.com"
+                {...register("email")}
+              />
+              {errors.email && (
+                <p className="text-sm text-destructive">{errors.email.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="create-password">Password</Label>
+              <Input
+                id="create-password"
+                type="password"
+                placeholder="Min 8 characters"
+                {...register("password")}
+              />
+              {errors.password && (
+                <p className="text-sm text-destructive">{errors.password.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="create-firstName">First name</Label>
+              <Input
+                id="create-firstName"
+                placeholder="Jane"
+                {...register("firstName")}
+              />
+              {errors.firstName && (
+                <p className="text-sm text-destructive">{errors.firstName.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="create-lastName">Last name</Label>
+              <Input
+                id="create-lastName"
+                placeholder="Admin"
+                {...register("lastName")}
+              />
+              {errors.lastName && (
+                <p className="text-sm text-destructive">{errors.lastName.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="create-phone">Phone (optional)</Label>
+              <Input
+                id="create-phone"
+                placeholder="+1 234 567 8900"
+                {...register("phoneNumber")}
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <Button type="submit" disabled={createSubmitting} className="w-full">
+                {createSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Creating…
+                  </>
+                ) : (
+                  "Create admin"
+                )}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All Users</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading users…
+            </div>
+          ) : users.length === 0 ? (
+            <p className="text-muted-foreground py-8">No users found.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.map((user) => {
+                  const isSelf = user.id === currentUser?.id;
+                  const busy = updatingId === user.id;
+                  return (
+                    <TableRow key={user.id}>
+                      <TableCell>
+                        {[user.firstName, user.lastName].filter(Boolean).join(" ") || "—"}
+                      </TableCell>
+                      <TableCell>{user.email}</TableCell>
+                      <TableCell>
+                        <select
+                          className="rounded-md border border-input bg-background px-2 py-1 text-sm w-full max-w-[120px]"
+                          value={user.role}
+                          onChange={(e) =>
+                            handleRoleChange(user, e.target.value as UserRole)
+                          }
+                          disabled={isSelf || busy}
+                        >
+                          <option value="USER">User</option>
+                          <option value="ORGANIZER">Organizer</option>
+                          <option value="ADMIN">Admin</option>
+                        </select>
+                      </TableCell>
+                      <TableCell>
+                        <select
+                          className="rounded-md border border-input bg-background px-2 py-1 text-sm w-full max-w-[160px]"
+                          value={user.status}
+                          onChange={(e) =>
+                            handleStatusChange(user, e.target.value as UserStatus)
+                          }
+                          disabled={isSelf || busy}
+                        >
+                          <option value="ACTIVE">Active</option>
+                          <option value="SUSPENDED">Suspended</option>
+                          <option value="PENDING_VERIFICATION">Pending verification</option>
+                        </select>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
   );
 };
 

--- a/eventpro-frontend/src/types/api.ts
+++ b/eventpro-frontend/src/types/api.ts
@@ -156,9 +156,18 @@ export interface Order {
   id: string;
   userId: string;
   totalAmount: number;
+  taxAmount?: number;
   status: "PENDING" | "COMPLETED" | "CANCELLED" | "REFUNDED";
   createdAt: string;
   tickets: Ticket[];
+}
+
+/** Subtotal, tax, and total for checkout. Use total for payment intent when tax is enabled. */
+export interface CheckoutTotals {
+  subtotal: number;
+  taxRatePercent: number;
+  tax: number;
+  total: number;
 }
 
 /** Attendee row from organizer event attendees list. */
@@ -284,8 +293,14 @@ export interface OrganizerSummary {
   ticketsSold: number;
   ticketsSoldTrendPercent: number | null;
   totalRevenue: number;
+  /** Platform fees withheld (tier-based). */
+  platformFeesWithheld?: number;
+  /** e.g. "2.9% + $0.79 per ticket (Pro)". */
+  platformFeeRateLabel?: string;
   availableBalance: number;
   pendingBalance: number;
+  /** Hold window in days; revenue from last N days is "pending". */
+  pendingHoldDays?: number;
   riskFlagged: boolean;
   riskLevel?: RiskLevel;
   /** True when W-9 submitted for 1099-K. */
@@ -398,6 +413,12 @@ export interface GuestConfirmPaymentRequest {
   receiveTicketViaWhatsApp?: boolean;
   /** Optional: send ticket via SMS. */
   receiveTicketViaSMS?: boolean;
+  /** Optional: buyer state (e.g. CA, NY) for sales tax. */
+  state?: string;
+  /** Optional: buyer country (e.g. US). */
+  country?: string;
+  /** Optional: tax amount when state/country was used at checkout. */
+  taxAmount?: number;
 }
 
 /** Options for "How did you hear about this event?" (cultural taxonomy). */

--- a/eventpro-frontend/src/types/api.ts
+++ b/eventpro-frontend/src/types/api.ts
@@ -236,6 +236,17 @@ export interface UpdateCartRequest {
   quantity: number;
 }
 
+/** Paginated response from admin/list endpoints (e.g. getUsers). */
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first?: boolean;
+  last?: boolean;
+}
+
 export interface ApiResponse<T> {
   success: boolean;
   message?: string;
@@ -388,6 +399,26 @@ export interface RevenueData {
   date: string;
   revenue: number;
   ticketsSold: number;
+}
+
+/** Pending KYC submission for admin review. */
+export interface PendingVerification {
+  id: string;
+  userId: string;
+  email: string;
+  legalEntityType: string;
+  addressCity: string;
+  addressState: string;
+  submittedAt: string;
+  status: string;
+}
+
+/** Request to record a Pro/Enterprise subscription payment (admin). */
+export interface RecordSubscriptionPaymentRequest {
+  userId: string;
+  amount: number;
+  tier?: "PRO" | "ENTERPRISE";
+  period?: "MONTHLY" | "YEARLY";
 }
 
 /** Request to create a Stripe payment intent (amount in dollars). */

--- a/eventpro-frontend/vite.config.ts
+++ b/eventpro-frontend/vite.config.ts
@@ -11,6 +11,16 @@ export default defineConfig(({ mode }) => ({
     hmr: {
       overlay: false,
     },
+    // In dev, proxy /api to backend so the app works without CORS and with backend in Docker (backend:8080) or on host (localhost:8080)
+    proxy:
+      mode === "development"
+        ? {
+            "/api": {
+              target: process.env.VITE_PROXY_TARGET || "http://localhost:8080",
+              changeOrigin: true,
+            },
+          }
+        : undefined,
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {


### PR DESCRIPTION
- Redirect Stripe success to /subscription/return; sync then redirect to Profile
- Sync API returns clear message; frontend shows it in toasts (Profile + Refresh)
- Hide "Refresh my plan" for PRO/ENTERPRISE; show "Current plan" on Pricing when already on tier
- Send subscription-upgraded email from webhook when tier/role updated (configurable)