### PR TITLE
feat(mobile): parity with web – event cards, guest checkout, follow, …

### DIFF
--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/EventProApplication.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/EventProApplication.java
@@ -2,10 +2,15 @@ package com.accessplus.eventpro;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.accessplus.eventpro")
 @EnableScheduling
+@EnableJpaRepositories(
+	basePackages = "com.accessplus.eventpro",
+	entityManagerFactoryRef = "entityManagerFactory"
+)
 public class EventProApplication {
 
 	public static void main(String[] args) {

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/EventController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.accessplus.eventpro.api.controller;
 
 import com.accessplus.eventpro.api.dto.ApiResponse;
+import com.accessplus.eventpro.api.dto.ContactOrganizerRequest;
 import com.accessplus.eventpro.api.dto.CreateEventRequest;
 import com.accessplus.eventpro.api.dto.EventAddonResponse;
 import com.accessplus.eventpro.api.dto.EventResponse;
@@ -9,6 +10,7 @@ import com.accessplus.eventpro.api.dto.TicketTypeResponse;
 import com.accessplus.eventpro.api.dto.UpdateEventRequest;
 import com.accessplus.eventpro.shared.exception.ResourceNotFoundException;
 import com.accessplus.eventpro.shared.exception.ValidationException;
+import com.accessplus.eventpro.core.email.service.EmailService;
 import com.accessplus.eventpro.core.security.JwtUtils;
 import com.accessplus.eventpro.core.user.service.UserService;
 import com.accessplus.eventpro.event.category.entity.CategoryEntity;
@@ -18,6 +20,7 @@ import com.accessplus.eventpro.event.addon.entity.EventAddonEntity;
 import com.accessplus.eventpro.event.addon.repository.EventAddonRepository;
 import com.accessplus.eventpro.event.event.repository.EventRepository;
 import com.accessplus.eventpro.event.event.service.EventService;
+import com.accessplus.eventpro.api.eventimage.repository.EventImageRepository;
 import com.accessplus.eventpro.event.ticket.service.TicketService;
 import com.accessplus.eventpro.shared.entity.TicketEntity;
 import com.accessplus.eventpro.shared.enums.EventStatus;
@@ -61,6 +64,8 @@ public class EventController extends BaseController {
     private final EventRepository eventRepository;
     private final EventAddonRepository eventAddonRepository;
     private final TicketService ticketService;
+    private final EmailService emailService;
+    private final EventImageRepository eventImageRepository;
     private final ObjectMapper objectMapper;
 
     @PostMapping
@@ -144,21 +149,70 @@ public class EventController extends BaseController {
         EventEntity event = eventRepository.findByIdWithOrganizer(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Event", id.toString()));
         EventResponse response = EventResponse.fromEntity(event);
+        List<String> galleryUrls = eventImageRepository.findByEventIdOrderByDisplayOrderAsc(id).stream()
+                .map(img -> img.getImageUrl())
+                .collect(Collectors.toList());
+        response.setAdditionalImageUrls(galleryUrls.isEmpty() ? null : galleryUrls);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @PostMapping("/{id}/contact")
+    @Operation(summary = "Contact organizer", description = "Sends a message to the event organizer. Public endpoint. Organizer email is not exposed.")
+    public ResponseEntity<ApiResponse<Void>> contactOrganizer(
+            @PathVariable UUID id,
+            @Valid @RequestBody ContactOrganizerRequest request) {
+        log.debug("Contact organizer for event: {}", id);
+
+        EventEntity event = eventRepository.findByIdWithOrganizer(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Event", id.toString()));
+        if (event.getStatus() != EventStatus.PUBLISHED) {
+            throw new ValidationException("Event is not available for contact.");
+        }
+        if (event.getOrganizer() == null || event.getOrganizer().getEmail() == null || event.getOrganizer().getEmail().isBlank()) {
+            log.warn("Cannot send contact message: event {} has no organizer email", id);
+            throw new ValidationException("Organizer contact is not available for this event.");
+        }
+
+        String organizerEmail = event.getOrganizer().getEmail();
+        String eventName = event.getName();
+        String senderName = request.getSenderName() != null && !request.getSenderName().isBlank()
+                ? request.getSenderName().trim() : "Someone";
+        String subject = "EventPro: Message about your event \"" + eventName + "\"";
+        String bodyText = String.format(
+                "You received a message about your event \"%s\".%n%nFrom: %s <%s>%n%nMessage:%n%s",
+                eventName, senderName, request.getSenderEmail(), request.getMessage());
+        String bodyHtml = String.format(
+                "<p>You received a message about your event <strong>%s</strong>.</p>" +
+                "<p><strong>From:</strong> %s &lt;%s&gt;</p>" +
+                "<p><strong>Message:</strong></p><p>%s</p>",
+                eventName.replace("<", "&lt;").replace(">", "&gt;"),
+                senderName.replace("<", "&lt;").replace(">", "&gt;"),
+                request.getSenderEmail().replace("<", "&lt;").replace(">", "&gt;"),
+                request.getMessage().replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>"));
+
+        try {
+            emailService.sendCustomEmail(organizerEmail, subject, bodyText, bodyHtml);
+        } catch (Exception e) {
+            log.error("Failed to send contact email for event {} to organizer: {}", id, e.getMessage(), e);
+            throw new ValidationException("Unable to send message. Please try again later.");
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(null, "Message sent."));
+    }
+
     @GetMapping
     @Operation(summary = "Get all events", description = "Returns paginated list of PUBLISHED events. " +
-            "Supports search by keyword (name). Public endpoint - only shows published events.")
+            "Supports search by keyword (name) and filter by organizerId. Public endpoint - only shows published events.")
     public ResponseEntity<ApiResponse<Page<EventResponse>>> getAllEvents(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "startTime") String sortBy,
             @RequestParam(defaultValue = "asc") String dir,
-            @RequestParam(required = false) String keyword) {
-        log.debug("Getting all published events: page={}, size={}, sortBy={}, dir={}, keyword={}",
-                page, size, sortBy, dir, keyword);
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) UUID organizerId) {
+        log.debug("Getting published events: page={}, size={}, sortBy={}, dir={}, keyword={}, organizerId={}",
+                page, size, sortBy, dir, keyword, organizerId);
 
         // Convert page from 1-based to 0-based
         int pageIndex = page > 0 ? page - 1 : 0;
@@ -173,8 +227,9 @@ public class EventController extends BaseController {
 
         Page<EventEntity> eventPage;
 
-        // Apply search filter if keyword provided - only show PUBLISHED events
-        if (keyword != null && !keyword.trim().isEmpty()) {
+        if (organizerId != null) {
+            eventPage = eventRepository.findByOrganizerIdAndStatus(organizerId, EventStatus.PUBLISHED, pageable);
+        } else if (keyword != null && !keyword.trim().isEmpty()) {
             eventPage = eventRepository.findByStatusAndNameContainingIgnoreCase(
                     EventStatus.PUBLISHED, keyword.trim(), pageable);
         } else {

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/OrganizerController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/OrganizerController.java
@@ -21,6 +21,8 @@ import com.accessplus.eventpro.event.addon.repository.EventAddonRepository;
 import com.accessplus.eventpro.event.event.entity.EventEntity;
 import com.accessplus.eventpro.event.event.repository.EventRepository;
 import com.accessplus.eventpro.event.event.service.EventService;
+import com.accessplus.eventpro.api.eventimage.entity.EventImageEntity;
+import com.accessplus.eventpro.api.eventimage.repository.EventImageRepository;
 import com.accessplus.eventpro.event.ticket.service.TicketService;
 import com.accessplus.eventpro.shared.entity.TicketEntity;
 import com.accessplus.eventpro.shared.exception.ResourceNotFoundException;
@@ -75,6 +77,7 @@ public class OrganizerController extends BaseController {
     private final OrganizerTeamService organizerTeamService;
     private final TaxFormPdfService taxFormPdfService;
     private final PayoutRequestService payoutRequestService;
+    private final EventImageRepository eventImageRepository;
 
     /** Merchandise & add-ons require Pro or Enterprise per pricing page. */
     private void requireAddonsEligible() {
@@ -490,6 +493,52 @@ public class OrganizerController extends BaseController {
             log.error("Failed to upload event image: {}", e.getMessage(), e);
             throw new RuntimeException("Failed to upload image: " + e.getMessage());
         }
+    }
+
+    @PostMapping("/events/{eventId}/images")
+    @PreAuthorize("hasAnyRole('ORGANIZER', 'ADMIN')")
+    @Operation(summary = "Add event gallery image", description = "Adds an image to the event gallery. Requires ORGANIZER or ADMIN role.")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> addEventImage(
+            @PathVariable UUID eventId,
+            @Valid @RequestBody AddEventImageRequest request) {
+        UUID organizerId = JwtUtils.getCurrentUserId();
+        EventEntity event = eventRepository.findByIdWithOrganizer(eventId)
+                .orElseThrow(() -> new ResourceNotFoundException("Event", eventId.toString()));
+        if (!canManageEvent(organizerId, event)) {
+            throw new ResourceNotFoundException("Event", eventId.toString());
+        }
+        int order = request.getDisplayOrder() != null ? request.getDisplayOrder() : (int) eventImageRepository.findByEventIdOrderByDisplayOrderAsc(eventId).stream().count();
+        EventImageEntity img = new EventImageEntity();
+        img.setEventId(eventId);
+        img.setImageUrl(request.getImageUrl().trim());
+        img.setDisplayOrder(order);
+        eventImageRepository.save(img);
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", img.getId());
+        data.put("imageUrl", img.getImageUrl());
+        data.put("displayOrder", img.getDisplayOrder());
+        return ResponseEntity.ok(ApiResponse.success(data, "Image added."));
+    }
+
+    @DeleteMapping("/events/{eventId}/images/{imageId}")
+    @PreAuthorize("hasAnyRole('ORGANIZER', 'ADMIN')")
+    @Operation(summary = "Remove event gallery image", description = "Removes an image from the event gallery.")
+    public ResponseEntity<ApiResponse<Void>> removeEventImage(
+            @PathVariable UUID eventId,
+            @PathVariable UUID imageId) {
+        UUID organizerId = JwtUtils.getCurrentUserId();
+        EventEntity event = eventRepository.findByIdWithOrganizer(eventId)
+                .orElseThrow(() -> new ResourceNotFoundException("Event", eventId.toString()));
+        if (!canManageEvent(organizerId, event)) {
+            throw new ResourceNotFoundException("Event", eventId.toString());
+        }
+        EventImageEntity img = eventImageRepository.findById(imageId)
+                .orElseThrow(() -> new ResourceNotFoundException("Event image", imageId.toString()));
+        if (!img.getEventId().equals(eventId)) {
+            throw new ResourceNotFoundException("Event image", imageId.toString());
+        }
+        eventImageRepository.delete(img);
+        return ResponseEntity.ok(ApiResponse.success(null, "Image removed."));
     }
 
     @PostMapping("/events/{eventId}/seat-map")

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/UserController.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/controller/UserController.java
@@ -4,10 +4,13 @@ import com.accessplus.eventpro.api.apikey.service.ApiKeyService;
 import com.accessplus.eventpro.api.dto.ApiKeyResponse;
 import com.accessplus.eventpro.api.dto.ApiResponse;
 import com.accessplus.eventpro.api.dto.CreateApiKeyRequest;
+import com.accessplus.eventpro.api.dto.FollowedOrganizerResponse;
+import com.accessplus.eventpro.api.dto.OrganizerPublicProfileResponse;
 import com.accessplus.eventpro.api.dto.PromoteUserRequest;
 import com.accessplus.eventpro.api.dto.UpdateUserRequest;
 import com.accessplus.eventpro.api.dto.UpgradeSubscriptionRequest;
 import com.accessplus.eventpro.api.dto.UserResponse;
+import com.accessplus.eventpro.api.follow.service.OrganizerFollowService;
 import com.accessplus.eventpro.core.security.JwtUtils;
 import com.accessplus.eventpro.core.user.entity.UserEntity;
 import com.accessplus.eventpro.core.user.service.UserService;
@@ -32,6 +35,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -46,6 +50,7 @@ public class UserController extends BaseController {
     private final UserService userService;
     private final AWSS3ImageService imageService;
     private final ApiKeyService apiKeyService;
+    private final OrganizerFollowService organizerFollowService;
 
     private void requireEnterprise() {
         UUID userId = JwtUtils.getCurrentUserId();
@@ -65,6 +70,33 @@ public class UserController extends BaseController {
         UserEntity user = userService.getUserById(userId);
         UserResponse response = UserResponse.fromEntity(user);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/me/following")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "List followed organizers", description = "Returns organizers the current user follows.")
+    public ResponseEntity<ApiResponse<List<FollowedOrganizerResponse>>> getFollowing() {
+        UUID userId = JwtUtils.getCurrentUserId();
+        List<FollowedOrganizerResponse> list = organizerFollowService.getFollowedOrganizersWithDetails(userId);
+        return ResponseEntity.ok(ApiResponse.success(list));
+    }
+
+    @PostMapping("/me/following/{organizerId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Follow organizer", description = "Follow an organizer to see their events in your Following list.")
+    public ResponseEntity<ApiResponse<Void>> followOrganizer(@PathVariable UUID organizerId) {
+        UUID userId = JwtUtils.getCurrentUserId();
+        organizerFollowService.follow(userId, organizerId);
+        return ResponseEntity.ok(ApiResponse.success(null, "Following."));
+    }
+
+    @DeleteMapping("/me/following/{organizerId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Unfollow organizer", description = "Stop following an organizer.")
+    public ResponseEntity<ApiResponse<Void>> unfollowOrganizer(@PathVariable UUID organizerId) {
+        UUID userId = JwtUtils.getCurrentUserId();
+        organizerFollowService.unfollow(userId, organizerId);
+        return ResponseEntity.ok(ApiResponse.success(null, "Unfollowed."));
     }
 
     @PutMapping("/me")
@@ -184,6 +216,20 @@ public class UserController extends BaseController {
             log.error("Failed to upload profile picture: {}", e.getMessage(), e);
             throw new ValidationException("Failed to upload profile picture: " + e.getMessage());
         }
+    }
+
+    @GetMapping("/{id}/public-profile")
+    @Operation(summary = "Get organizer public profile", description = "Returns display-only profile (name, photo) for an organizer. Public; used to show organizer on event pages.")
+    public ResponseEntity<ApiResponse<OrganizerPublicProfileResponse>> getOrganizerPublicProfile(@PathVariable UUID id) {
+        log.debug("Getting public profile for user: {}", id);
+        UserEntity user = userService.getUserById(id);
+        OrganizerPublicProfileResponse response = OrganizerPublicProfileResponse.builder()
+                .id(user.getId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .profilePictureUrl(user.getProfilePictureUrl())
+                .build();
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/{id}")

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/AddEventImageRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/AddEventImageRequest.java
@@ -1,0 +1,21 @@
+package com.accessplus.eventpro.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddEventImageRequest {
+
+    @NotBlank(message = "Image URL is required")
+    @Size(max = 500)
+    private String imageUrl;
+
+    private Integer displayOrder;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/ContactOrganizerRequest.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/ContactOrganizerRequest.java
@@ -1,0 +1,27 @@
+package com.accessplus.eventpro.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactOrganizerRequest {
+
+    @NotBlank(message = "Email is required")
+    @Email
+    private String senderEmail;
+
+    @Size(max = 200)
+    private String senderName;
+
+    @NotBlank(message = "Message is required")
+    @Size(max = 2000)
+    private String message;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/EventResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/EventResponse.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -22,6 +23,8 @@ public class EventResponse {
     private String name;
     private String description;
     private String imageUrl;
+    /** Additional images for gallery (primary image is imageUrl). */
+    private List<String> additionalImageUrls;
     private String promotionalVideoUrl;
     private String eventPageTemplate;
     private Boolean marketingEnabled;
@@ -37,6 +40,10 @@ public class EventResponse {
     private String organizerBrandingPrimaryColor;
     /** White-label: hide platform branding on this event page. */
     private Boolean organizerBrandingHidePlatform;
+    /** Organizer display info for event detail (name, avatar). */
+    private String organizerFirstName;
+    private String organizerLastName;
+    private String organizerProfilePictureUrl;
     private EventStatus status;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
@@ -71,10 +78,28 @@ public class EventResponse {
                 .startTime(entity.getStartTime())
                 .endTime(entity.getEndTime());
         
-        // Set organizer (userId) and white-label branding
+        // Set organizer (userId), display info, and white-label branding
         if (entity.getOrganizer() != null) {
             var org = entity.getOrganizer();
+            String first = org.getFirstName();
+            String last = org.getLastName();
+            // If organizer has no first/last name set, derive display name from email (e.g. "john" from "john@example.com")
+            if ((first == null || first.isBlank()) && (last == null || last.isBlank()) && org.getEmail() != null && !org.getEmail().isBlank()) {
+                String emailLocal = org.getEmail().split("@")[0].trim();
+                if (!emailLocal.isEmpty()) {
+                    first = emailLocal;
+                    last = null;
+                }
+            }
+            // Ensure at least one display label so clients never get null for both (e.g. legacy accounts with no name/email set)
+            if ((first == null || first.isBlank()) && (last == null || last.isBlank())) {
+                first = "Organizer";
+                last = null;
+            }
             builder.userId(org.getId())
+                    .organizerFirstName(first)
+                    .organizerLastName(last)
+                    .organizerProfilePictureUrl(org.getProfilePictureUrl())
                     .organizerBrandingLogoUrl(org.getBrandingLogoUrl())
                     .organizerBrandingPrimaryColor(org.getBrandingPrimaryColor())
                     .organizerBrandingHidePlatform(org.getBrandingHidePlatform() != null ? org.getBrandingHidePlatform() : false);

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/FollowedOrganizerResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/FollowedOrganizerResponse.java
@@ -1,0 +1,21 @@
+package com.accessplus.eventpro.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/** Minimal organizer info for "Following" list. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowedOrganizerResponse {
+
+    private UUID organizerId;
+    private String firstName;
+    private String lastName;
+    private String profilePictureUrl;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/OrganizerPublicProfileResponse.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/dto/OrganizerPublicProfileResponse.java
@@ -1,0 +1,25 @@
+package com.accessplus.eventpro.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * Public display profile for an organizer (name, photo only).
+ * Used when showing organizer on event detail; data comes from the organizer's profile.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganizerPublicProfileResponse {
+    private UUID id;
+    private String firstName;
+    private String lastName;
+    private String profilePictureUrl;
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/eventimage/entity/EventImageEntity.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/eventimage/entity/EventImageEntity.java
@@ -1,0 +1,40 @@
+package com.accessplus.eventpro.api.eventimage.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "event_images", indexes = @Index(name = "idx_event_images_event_id", columnList = "event_id"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventImageEntity {
+
+    @Id
+    @GeneratedValue
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "event_id", nullable = false)
+    @JdbcTypeCode(SqlTypes.UUID)
+    private UUID eventId;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/eventimage/repository/EventImageRepository.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/eventimage/repository/EventImageRepository.java
@@ -1,0 +1,14 @@
+package com.accessplus.eventpro.api.eventimage.repository;
+
+import com.accessplus.eventpro.api.eventimage.entity.EventImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface EventImageRepository extends JpaRepository<EventImageEntity, UUID> {
+
+    List<EventImageEntity> findByEventIdOrderByDisplayOrderAsc(UUID eventId);
+
+    void deleteByEventId(UUID eventId);
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/follow/entity/OrganizerFollowEntity.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/follow/entity/OrganizerFollowEntity.java
@@ -1,0 +1,41 @@
+package com.accessplus.eventpro.api.follow.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "organizer_follows", indexes = {
+    @Index(name = "idx_organizer_follows_user_id", columnList = "user_id"),
+    @Index(name = "idx_organizer_follows_organizer_id", columnList = "organizer_id")
+}, uniqueConstraints = @UniqueConstraint(columnNames = { "user_id", "organizer_id" }))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrganizerFollowEntity {
+
+    @Id
+    @GeneratedValue
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    @JdbcTypeCode(SqlTypes.UUID)
+    private UUID userId;
+
+    @Column(name = "organizer_id", nullable = false)
+    @JdbcTypeCode(SqlTypes.UUID)
+    private UUID organizerId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/follow/repository/OrganizerFollowRepository.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/follow/repository/OrganizerFollowRepository.java
@@ -1,0 +1,22 @@
+package com.accessplus.eventpro.api.follow.repository;
+
+import com.accessplus.eventpro.api.follow.entity.OrganizerFollowEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrganizerFollowRepository extends JpaRepository<OrganizerFollowEntity, UUID> {
+
+    Optional<OrganizerFollowEntity> findByUserIdAndOrganizerId(UUID userId, UUID organizerId);
+
+    boolean existsByUserIdAndOrganizerId(UUID userId, UUID organizerId);
+
+    List<OrganizerFollowEntity> findByUserIdOrderByCreatedAtDesc(UUID userId);
+
+    @Query("SELECT f.organizerId FROM OrganizerFollowEntity f WHERE f.userId = :userId")
+    List<UUID> findOrganizerIdsByUserId(@Param("userId") UUID userId);
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/follow/service/OrganizerFollowService.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/follow/service/OrganizerFollowService.java
@@ -1,0 +1,84 @@
+package com.accessplus.eventpro.api.follow.service;
+
+import com.accessplus.eventpro.api.dto.FollowedOrganizerResponse;
+import com.accessplus.eventpro.api.follow.entity.OrganizerFollowEntity;
+import com.accessplus.eventpro.api.follow.repository.OrganizerFollowRepository;
+import com.accessplus.eventpro.core.user.entity.UserEntity;
+import com.accessplus.eventpro.core.user.repository.UserRepository;
+import com.accessplus.eventpro.shared.exception.ResourceNotFoundException;
+import com.accessplus.eventpro.shared.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrganizerFollowService {
+
+    private final OrganizerFollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void follow(UUID userId, UUID organizerId) {
+        if (userId.equals(organizerId)) {
+            throw new ValidationException("You cannot follow yourself.");
+        }
+        if (!userRepository.existsById(organizerId)) {
+            throw new ResourceNotFoundException("Organizer", organizerId.toString());
+        }
+        if (followRepository.existsByUserIdAndOrganizerId(userId, organizerId)) {
+            return; // already following
+        }
+        OrganizerFollowEntity follow = new OrganizerFollowEntity();
+        follow.setUserId(userId);
+        follow.setOrganizerId(organizerId);
+        followRepository.save(follow);
+        log.debug("User {} followed organizer {}", userId, organizerId);
+    }
+
+    @Transactional
+    public void unfollow(UUID userId, UUID organizerId) {
+        followRepository.findByUserIdAndOrganizerId(userId, organizerId)
+                .ifPresent(followRepository::delete);
+        log.debug("User {} unfollowed organizer {}", userId, organizerId);
+    }
+
+    public boolean isFollowing(UUID userId, UUID organizerId) {
+        return followRepository.existsByUserIdAndOrganizerId(userId, organizerId);
+    }
+
+    public List<UUID> getFollowedOrganizerIds(UUID userId) {
+        return followRepository.findOrganizerIdsByUserId(userId);
+    }
+
+    public List<OrganizerFollowEntity> getFollowsByUserId(UUID userId) {
+        return followRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    public List<FollowedOrganizerResponse> getFollowedOrganizersWithDetails(UUID userId) {
+        List<OrganizerFollowEntity> follows = followRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        if (follows.isEmpty()) return List.of();
+        List<UUID> organizerIds = follows.stream().map(OrganizerFollowEntity::getOrganizerId).distinct().toList();
+        Map<UUID, UserEntity> users = userRepository.findAllById(organizerIds).stream().collect(Collectors.toMap(UserEntity::getId, u -> u));
+        List<FollowedOrganizerResponse> result = new ArrayList<>();
+        for (OrganizerFollowEntity f : follows) {
+            UserEntity org = users.get(f.getOrganizerId());
+            if (org == null) continue;
+            result.add(FollowedOrganizerResponse.builder()
+                    .organizerId(org.getId())
+                    .firstName(org.getFirstName())
+                    .lastName(org.getLastName())
+                    .profilePictureUrl(org.getProfilePictureUrl())
+                    .build());
+        }
+        return result;
+    }
+}

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/notification/entity/NotificationEntity.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/notification/entity/NotificationEntity.java
@@ -29,7 +29,7 @@ public class NotificationEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @JdbcTypeCode(SqlTypes.UUID)
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/notification/entity/NotificationPreferenceEntity.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/notification/entity/NotificationPreferenceEntity.java
@@ -27,7 +27,7 @@ public class NotificationPreferenceEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @JdbcTypeCode(SqlTypes.UUID)
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
@@ -40,7 +40,7 @@ public class NotificationPreferenceEntity {
     @Column(name = "push_enabled", nullable = false)
     private boolean pushEnabled = true; // used for in-app when push not implemented
 
-    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @JdbcTypeCode(SqlTypes.UUID)
     @Column(name = "user_id", nullable = false)
     private UUID userId;
 

--- a/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/notification/entity/UserNotificationEntity.java
+++ b/backend/services/modules/eventpro-api/src/main/java/com/accessplus/eventpro/api/notification/entity/UserNotificationEntity.java
@@ -30,7 +30,7 @@ public class UserNotificationEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @JdbcTypeCode(SqlTypes.UUID)
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
@@ -40,7 +40,7 @@ public class UserNotificationEntity {
     @Column(name = "read_at")
     private Instant readAt;
 
-    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @JdbcTypeCode(SqlTypes.UUID)
     @Column(name = "user_id", nullable = false)
     private UUID userId;
 

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V31__organizer_follows.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V31__organizer_follows.sql
@@ -1,0 +1,12 @@
+-- Users can follow organizers to see their events in a "Following" feed.
+CREATE TABLE IF NOT EXISTS organizer_follows (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    organizer_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, organizer_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_organizer_follows_user_id ON organizer_follows(user_id);
+CREATE INDEX IF NOT EXISTS idx_organizer_follows_organizer_id ON organizer_follows(organizer_id);
+COMMENT ON TABLE organizer_follows IS 'Users following organizers; used for Following list and optional feed.';

--- a/backend/services/modules/eventpro-api/src/main/resources/db/migration/V32__event_images.sql
+++ b/backend/services/modules/eventpro-api/src/main/resources/db/migration/V32__event_images.sql
@@ -1,0 +1,11 @@
+-- Multiple images per event for gallery on event detail page.
+CREATE TABLE IF NOT EXISTS event_images (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    image_url VARCHAR(500) NOT NULL,
+    display_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_images_event_id ON event_images(event_id);
+COMMENT ON TABLE event_images IS 'Additional event images for gallery; primary image remains on events.image_url.';

--- a/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/security/SecurityConfig.java
+++ b/backend/services/modules/eventpro-core/src/main/java/com/accessplus/eventpro/core/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/v1/events/*/addons").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/events/category/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/images/proxy").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/users/*/public-profile").permitAll()
                 // Payment config (Stripe publishable key for frontend) - public
                 .requestMatchers(HttpMethod.GET, "/api/v1/payments/config").permitAll()
                 // Guest checkout: no auth required (endpoint exists in PaymentController)

--- a/docs/MVP_ROADMAP.md
+++ b/docs/MVP_ROADMAP.md
@@ -178,4 +178,18 @@ Use this doc as the single source of truth; keep the **Status** column and check
 - **Tiered payouts execution:** Wire 50% early (Pro) and 100% instant (Enterprise) to real payout flow once bank and risk are in place.
 - **Dynamic pricing, multi-currency, SLA, on-premise:** Per pricing page, these are Enterprise; not yet implemented.
 
+**Event page & organizer**
+
+- [ ] **Organizer on event:** Show organizer (name, avatar, link) on event detail (web + mobile).
+- [ ] **Other events by organizer:** “More from this organizer” / “Other events” by same organizer (web + mobile).
+- [ ] **Contact organizer:** “Contact organizer” (email or in-app) from event page.
+- [ ] **Follow organizers:** Follow/unfollow; “Following” list; optionally “Events from organizers you follow”.
+
+**Event media**
+
+- [ ] **Multiple event images:** Multiple images per event (gallery/carousel); backend + web + mobile.
+- [ ] **Promotional video on mobile:** Render `promotionalVideoUrl` (e.g. YouTube) in mobile EventDetailScreen (web already has embed).
+
+---
+
 See also: `docs/TODO-identity-check-and-verification.md` for the full KYC checklist.

--- a/eventpro-frontend/src/App.tsx
+++ b/eventpro-frontend/src/App.tsx
@@ -20,6 +20,7 @@ import EventDetails from "./pages/EventDetails";
 import Checkout from "./pages/Checkout";
 import Profile from "./pages/Profile";
 import ProfileEdit from "./pages/ProfileEdit";
+import Following from "./pages/Following";
 import Settings from "./pages/Settings";
 import SignUp from "./pages/SignUp";
 import Verify from "./pages/Verify";
@@ -100,6 +101,14 @@ const AnimatedRoutes = () => {
           element={
             <ProtectedRoute>
               <PageTransition><ProfileEdit /></PageTransition>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/profile/following"
+          element={
+            <ProtectedRoute>
+              <PageTransition><Following /></PageTransition>
             </ProtectedRoute>
           }
         />

--- a/eventpro-frontend/src/components/Navigation.tsx
+++ b/eventpro-frontend/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Menu, X, Ticket, Calendar, User as UserIcon, ShoppingBag, LogOut, Settings, Shield } from "lucide-react";
+import { Menu, X, Ticket, Calendar, User as UserIcon, ShoppingBag, LogOut, Settings, Shield, Heart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { Badge } from "@/components/ui/badge";
@@ -26,6 +26,7 @@ export const Navigation = () => {
 
   if (isAuthenticated) {
     navLinks.push({ path: "/orders", label: "My Orders", icon: ShoppingBag });
+    navLinks.push({ path: "/profile/following", label: "Following", icon: Heart });
     navLinks.push({ path: "/profile", label: "Profile", icon: UserIcon });
   }
 

--- a/eventpro-frontend/src/lib/api.ts
+++ b/eventpro-frontend/src/lib/api.ts
@@ -36,6 +36,7 @@ import type {
   RecordSubscriptionPaymentRequest,
   UserNotification,
   NotificationPreferences,
+  FollowedOrganizer,
 } from "@/types/api";
 
 class ApiService {
@@ -85,6 +86,19 @@ class ApiService {
   async getCurrentUser(): Promise<User> {
     const response = await this.api.get<ApiResponse<User>>("/api/v1/users/me");
     return response.data.data;
+  }
+
+  async getFollowing(): Promise<FollowedOrganizer[]> {
+    const response = await this.api.get<ApiResponse<FollowedOrganizer[]>>("/api/v1/users/me/following");
+    return response.data.data ?? [];
+  }
+
+  async followOrganizer(organizerId: string): Promise<void> {
+    await this.api.post<ApiResponse<null>>(`/api/v1/users/me/following/${organizerId}`);
+  }
+
+  async unfollowOrganizer(organizerId: string): Promise<void> {
+    await this.api.delete<ApiResponse<null>>(`/api/v1/users/me/following/${organizerId}`);
   }
 
   /** Create Stripe Checkout Session for subscription. Redirect user to returned url. After payment, webhooks update tier. */
@@ -143,6 +157,16 @@ class ApiService {
     return response.data.data;
   }
 
+  /** Upload profile picture (organizers and any user). Returns new profile picture URL. */
+  async uploadProfilePicture(file: File): Promise<string> {
+    const formData = new FormData();
+    formData.append("image", file);
+    const response = await this.api.post<ApiResponse<{ url: string }>>("/api/v1/users/upload-profile-picture", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return response.data.data.url;
+  }
+
   /** List in-app notifications for current user (paginated). */
   async getMyNotifications(page = 0, size = 20): Promise<PageResponse<UserNotification>> {
     const response = await this.api.get<ApiResponse<PageResponse<UserNotification>>>(
@@ -189,14 +213,15 @@ class ApiService {
   }
 
   // Event endpoints
-  async getEvents(page = 1, size = 20, keyword?: string): Promise<Event[]> {
+  async getEvents(page = 1, size = 20, keyword?: string, organizerId?: string): Promise<Event[]> {
     const params = new URLSearchParams();
-    params.append("page", String(page - 1));
+    params.append("page", String(page));
     params.append("size", String(size));
     if (keyword) params.append("keyword", keyword);
-    
+    if (organizerId) params.append("organizerId", organizerId);
+
     const response = await this.api.get<ApiResponse<{ content: Event[] }>>(`/api/v1/events?${params}`);
-    return response.data.data.content || [];
+    return response.data.data.content ?? [];
   }
 
   async getEventsByCategory(category: string): Promise<Event[]> {
@@ -207,6 +232,13 @@ class ApiService {
   async getEvent(id: string): Promise<Event> {
     const response = await this.api.get<ApiResponse<Event>>(`/api/v1/events/${id}`);
     return response.data.data;
+  }
+
+  async contactOrganizer(
+    eventId: string,
+    body: { senderEmail: string; senderName?: string; message: string }
+  ): Promise<void> {
+    await this.api.post<ApiResponse<null>>(`/api/v1/events/${eventId}/contact`, body);
   }
 
   async createEvent(data: Partial<Event>): Promise<Event> {

--- a/eventpro-frontend/src/pages/EventDetails.tsx
+++ b/eventpro-frontend/src/pages/EventDetails.tsx
@@ -3,8 +3,18 @@ import { useParams, useNavigate } from "react-router-dom";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Calendar, MapPin, Clock, Ticket, Minus, Plus, Grid3X3 } from "lucide-react";
+import { Calendar, MapPin, Clock, Ticket, Minus, Plus, Grid3X3, User } from "lucide-react";
+import { Link } from "react-router-dom";
 import { apiService } from "@/lib/api";
 import type { Event, TicketType, SeatResponse } from "@/types/api";
 import { useCart } from "@/contexts/CartContext";
@@ -15,6 +25,9 @@ import { getEventImageUrl, getPromotionalVideoEmbedUrl } from "@/lib/utils";
 import { SeatingMap, generateSampleSeats, Seat } from "@/components/SeatingMap";
 import { ShareActionsContainer } from "@/components/ShareActions";
 import { LiveAttendanceBadge, useSimulatedViewers } from "@/components/LiveAttendanceBadge";
+import { EventCard } from "@/components/EventCard";
+import { useAuth } from "@/contexts/AuthContext";
+import { toast } from "sonner";
 
 const EventDetails = () => {
   const { id } = useParams<{ id: string }>();
@@ -27,6 +40,11 @@ const EventDetails = () => {
   const [quantities, setQuantities] = useState<Record<string, number>>({});
   const [selectedSeats, setSelectedSeats] = useState<Seat[]>([]);
   const [ticketMode, setTicketMode] = useState<"general" | "seating">("general");
+  const [otherEventsByOrganizer, setOtherEventsByOrganizer] = useState<Event[]>([]);
+  const [contactDialogOpen, setContactDialogOpen] = useState(false);
+  const [contactForm, setContactForm] = useState({ senderName: "", senderEmail: "", message: "" });
+  const [contactSubmitting, setContactSubmitting] = useState(false);
+  const [contactSent, setContactSent] = useState(false);
   // Default to seating tab when event has reserved seating (with seats) and no GA types
   useEffect(() => {
     if (event?.reservedSeatingEnabled && seatResponses.length > 0 && ticketTypes.length === 0) {
@@ -35,6 +53,10 @@ const EventDetails = () => {
   }, [event?.reservedSeatingEnabled, seatResponses.length, ticketTypes.length]);
   const { addItem } = useCart();
   const { addRecentlyViewed } = usePreferences();
+  const { isAuthenticated } = useAuth();
+  const [followedOrganizerIds, setFollowedOrganizerIds] = useState<Set<string>>(new Set());
+  const [followLoading, setFollowLoading] = useState(false);
+  const [galleryIndex, setGalleryIndex] = useState(0);
 
   // Reserved seating: map API seats to SeatingMap Seat format
   const seatsFromApi = useMemo(() => {
@@ -50,6 +72,13 @@ const EventDetails = () => {
   }, [seatResponses]);
 
   const hasReservedSeating = Boolean(event?.reservedSeatingEnabled && seatsFromApi.length > 0);
+  const galleryImages = useMemo(() => {
+    if (!event) return [];
+    const main = event.imageUrl ? [event.imageUrl] : [];
+    const extra = event.additionalImageUrls ?? [];
+    return [...main, ...extra].filter(Boolean);
+  }, [event?.imageUrl, event?.additionalImageUrls]);
+  const showGallery = galleryImages.length > 1;
   /** Event has reserved seating enabled but organizer hasn't created a seat map yet */
   const reservedSeatingPending = Boolean(event?.reservedSeatingEnabled && seatsFromApi.length === 0);
   const showSeatingTab = hasReservedSeating || reservedSeatingPending;
@@ -78,6 +107,21 @@ const EventDetails = () => {
       loadEventDetails();
     }
   }, [id]);
+
+  // Load other events by same organizer (for "More from this organizer" section)
+  useEffect(() => {
+    if (!event?.userId || !id) return;
+    apiService
+      .getEvents(1, 6, undefined, event.userId)
+      .then((list) => setOtherEventsByOrganizer(list.filter((e) => e.id !== id)))
+      .catch(() => setOtherEventsByOrganizer([]));
+  }, [event?.userId, id]);
+
+  // Load followed organizers when logged in (for Follow/Unfollow button)
+  useEffect(() => {
+    if (!isAuthenticated || !event?.userId) return;
+    apiService.getFollowing().then((list) => setFollowedOrganizerIds(new Set(list.map((o) => o.organizerId))));
+  }, [isAuthenticated, event?.userId]);
 
   const loadEventDetails = async () => {
     try {
@@ -228,7 +272,32 @@ const EventDetails = () => {
               isMinimal ? "space-y-8 max-w-2xl" : ""
             } ${isVibrant ? "rounded-2xl p-4 md:p-6 bg-gradient-to-br from-primary/5 to-primary/10 dark:from-primary/10 dark:to-primary/5" : ""}`}
           >
-            {(event.imageUrl && !imgError) ? (
+            {showGallery ? (
+              <>
+                <div className="rounded-xl overflow-hidden h-64 md:h-96">
+                  <img
+                    src={getEventImageUrl(galleryImages[galleryIndex]) ?? ""}
+                    alt={`${event.name} (${galleryIndex + 1}/${galleryImages.length})`}
+                    className="w-full h-full object-cover"
+                    onError={() => setImgError(true)}
+                  />
+                </div>
+                <div className="flex gap-2 mt-2 overflow-x-auto pb-1">
+                  {galleryImages.map((url, i) => (
+                    <button
+                      key={url + i}
+                      type="button"
+                      onClick={() => setGalleryIndex(i)}
+                      className={`shrink-0 w-16 h-16 rounded-lg overflow-hidden border-2 transition-colors ${
+                        i === galleryIndex ? "border-primary ring-2 ring-primary/30" : "border-transparent opacity-80 hover:opacity-100"
+                      }`}
+                    >
+                      <img src={getEventImageUrl(url) ?? ""} alt="" className="w-full h-full object-cover" />
+                    </button>
+                  ))}
+                </div>
+              </>
+            ) : (event.imageUrl && !imgError) ? (
               <div className="rounded-xl overflow-hidden h-64 md:h-96">
                 <img
                   src={getEventImageUrl(event.imageUrl) ?? ""}
@@ -285,6 +354,142 @@ const EventDetails = () => {
                   <p>{event.description}</p>
                 </div>
               )}
+
+              {/* Organizer — name, avatar, link to more events, contact */}
+              {(event.userId || event.organizerFirstName || event.organizerLastName) && (
+                <div className="flex flex-col sm:flex-row sm:items-center gap-3 py-3 border-t border-b border-border/60">
+                  {event.organizerProfilePictureUrl ? (
+                    <img
+                      src={event.organizerProfilePictureUrl}
+                      alt=""
+                      className="h-12 w-12 rounded-full object-cover bg-muted"
+                    />
+                  ) : (
+                    <div className="h-12 w-12 rounded-full bg-muted flex items-center justify-center">
+                      <User className="h-6 w-6 text-muted-foreground" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-muted-foreground">Organized by</p>
+                    {event.userId ? (
+                      <Link
+                        to={`/events?organizerId=${event.userId}`}
+                        className="font-semibold text-foreground hover:text-primary hover:underline truncate block"
+                      >
+                        {[event.organizerFirstName, event.organizerLastName].filter(Boolean).join(" ") || "Organizer"}
+                      </Link>
+                    ) : (
+                      <span className="font-semibold text-foreground truncate block">
+                        {[event.organizerFirstName, event.organizerLastName].filter(Boolean).join(" ") || "Organizer"}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    {isAuthenticated && event.userId && (
+                      <Button
+                        variant={followedOrganizerIds.has(event.userId) ? "default" : "outline"}
+                        size="sm"
+                        disabled={followLoading}
+                        className={followedOrganizerIds.has(event.userId) ? "bg-primary text-primary-foreground" : ""}
+                        onClick={async () => {
+                          if (!event.userId) return;
+                          setFollowLoading(true);
+                          try {
+                            const name = [event.organizerFirstName, event.organizerLastName].filter(Boolean).join(" ") || "this organizer";
+                            if (followedOrganizerIds.has(event.userId)) {
+                              await apiService.unfollowOrganizer(event.userId);
+                              setFollowedOrganizerIds((s) => { const n = new Set(s); n.delete(event.userId!); return n; });
+                              toast.success(`Unfollowed ${name}`);
+                            } else {
+                              await apiService.followOrganizer(event.userId);
+                              setFollowedOrganizerIds((s) => new Set(s).add(event.userId!));
+                              toast.success(`Following ${name}. See them in Following.`);
+                            }
+                          } finally {
+                            setFollowLoading(false);
+                          }
+                        }}
+                      >
+                        {followLoading ? "…" : followedOrganizerIds.has(event.userId) ? "Followed" : "Follow"}
+                      </Button>
+                    )}
+                    <Button variant="ghost" size="sm" className="border border-dashed border-input" onClick={() => { setContactDialogOpen(true); setContactSent(false); setContactForm({ senderName: "", senderEmail: "", message: "" }); }}>
+                      Contact organizer
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {/* Contact organizer dialog */}
+              <Dialog open={contactDialogOpen} onOpenChange={setContactDialogOpen}>
+                <DialogContent className="sm:max-w-md">
+                  <DialogHeader>
+                    <DialogTitle>Contact organizer</DialogTitle>
+                  </DialogHeader>
+                  {contactSent ? (
+                    <p className="text-muted-foreground py-4">Your message has been sent. The organizer will get back to you by email.</p>
+                  ) : (
+                    <form
+                      className="space-y-4"
+                      onSubmit={async (e) => {
+                        e.preventDefault();
+                        if (!event?.id || !contactForm.senderEmail.trim() || !contactForm.message.trim()) return;
+                        setContactSubmitting(true);
+                        try {
+                          await apiService.contactOrganizer(event.id, {
+                            senderEmail: contactForm.senderEmail.trim(),
+                            senderName: contactForm.senderName.trim() || undefined,
+                            message: contactForm.message.trim(),
+                          });
+                          setContactSent(true);
+                        } catch (err) {
+                          console.error(err);
+                        } finally {
+                          setContactSubmitting(false);
+                        }
+                      }}
+                    >
+                      <div className="space-y-2">
+                        <Label htmlFor="contact-name">Your name (optional)</Label>
+                        <Input
+                          id="contact-name"
+                          value={contactForm.senderName}
+                          onChange={(e) => setContactForm((f) => ({ ...f, senderName: e.target.value }))}
+                          placeholder="Jane Doe"
+                          maxLength={200}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="contact-email">Your email *</Label>
+                        <Input
+                          id="contact-email"
+                          type="email"
+                          required
+                          value={contactForm.senderEmail}
+                          onChange={(e) => setContactForm((f) => ({ ...f, senderEmail: e.target.value }))}
+                          placeholder="you@example.com"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="contact-message">Message *</Label>
+                        <textarea
+                          id="contact-message"
+                          required
+                          value={contactForm.message}
+                          onChange={(e) => setContactForm((f) => ({ ...f, message: e.target.value }))}
+                          placeholder="Your message to the organizer..."
+                          className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                          maxLength={2000}
+                        />
+                      </div>
+                      <DialogFooter>
+                        <Button type="button" variant="outline" onClick={() => setContactDialogOpen(false)}>Cancel</Button>
+                        <Button type="submit" disabled={contactSubmitting}>{contactSubmitting ? "Sending…" : "Send message"}</Button>
+                      </DialogFooter>
+                    </form>
+                  )}
+                </DialogContent>
+              </Dialog>
 
               {/* Promotional video (YouTube/Vimeo embed) — Basic theming, all tiers */}
               {event.promotionalVideoUrl && getPromotionalVideoEmbedUrl(event.promotionalVideoUrl) && (
@@ -455,6 +660,26 @@ const EventDetails = () => {
               </TabsContent>
             </Tabs>
           </div>
+
+          {/* More from this organizer — full-width row */}
+          {event.userId && otherEventsByOrganizer.length > 0 && (
+            <div className="lg:col-span-3 mt-10 pt-8 border-t border-border/60">
+              <h2 className="text-2xl font-bold mb-4">More from this organizer</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {otherEventsByOrganizer.slice(0, 3).map((e, index) => (
+                  <EventCard key={e.id} event={e} index={index} />
+                ))}
+              </div>
+              <div className="mt-4">
+                <Link
+                  to={`/events?organizerId=${event.userId}`}
+                  className="text-primary font-medium hover:underline"
+                >
+                  View all events by this organizer →
+                </Link>
+              </div>
+            </div>
+          )}
         </motion.div>
       </div>
       {!hidePlatformBranding && (

--- a/eventpro-frontend/src/pages/Events.tsx
+++ b/eventpro-frontend/src/pages/Events.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,6 +22,8 @@ const EVENT_CATEGORIES = [
 ];
 
 const Events = () => {
+  const [searchParams] = useSearchParams();
+  const organizerIdFromUrl = searchParams.get("organizerId") ?? undefined;
   const [events, setEvents] = useState<Event[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
@@ -28,6 +31,7 @@ const Events = () => {
   const searchDebounceTimerRef = useRef<NodeJS.Timeout | null>(null);
   const prevSearchQueryRef = useRef<string>("");
   const prevCategoryRef = useRef<string | undefined>(undefined);
+  const prevOrganizerIdRef = useRef<string | undefined>(undefined);
   const isInitialMount = useRef(true);
 
   const loadEvents = useCallback(async () => {
@@ -38,7 +42,7 @@ const Events = () => {
       if (selectedCategory) {
         data = await apiService.getEventsByCategory(selectedCategory);
       } else {
-        data = await apiService.getEvents(1, 20, searchQuery || undefined);
+        data = await apiService.getEvents(1, 20, searchQuery || undefined, organizerIdFromUrl);
       }
 
       setEvents(data);
@@ -48,7 +52,7 @@ const Events = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [selectedCategory, searchQuery]);
+  }, [selectedCategory, searchQuery, organizerIdFromUrl]);
 
   useEffect(() => {
     if (searchDebounceTimerRef.current) {
@@ -60,17 +64,20 @@ const Events = () => {
       isInitialMount.current = false;
       prevSearchQueryRef.current = searchQuery;
       prevCategoryRef.current = selectedCategory;
+      prevOrganizerIdRef.current = organizerIdFromUrl;
       loadEvents();
       return;
     }
 
     const searchQueryChanged = searchQuery !== prevSearchQueryRef.current;
     const categoryChanged = selectedCategory !== prevCategoryRef.current;
+    const organizerIdChanged = organizerIdFromUrl !== prevOrganizerIdRef.current;
 
     prevSearchQueryRef.current = searchQuery;
     prevCategoryRef.current = selectedCategory;
+    prevOrganizerIdRef.current = organizerIdFromUrl;
 
-    if (categoryChanged) {
+    if (categoryChanged || organizerIdChanged) {
       loadEvents();
       return;
     }
@@ -138,10 +145,12 @@ const Events = () => {
           <div className="relative px-4 py-6 sm:py-8">
             {/* Header */}
             <h1 className="text-4xl md:text-5xl font-extrabold font-heading tracking-tight text-gradient-hero mb-2">
-              Discover Events
+              {organizerIdFromUrl ? "More from this organizer" : "Discover Events"}
             </h1>
             <p className="text-xl text-muted-foreground mb-6">
-              Find and book tickets for amazing events
+              {organizerIdFromUrl
+                ? "Other events by the same organizer"
+                : "Find and book tickets for amazing events"}
             </p>
 
             {/* Search bar - glassmorphism + vibrant focus */}

--- a/eventpro-frontend/src/pages/Following.tsx
+++ b/eventpro-frontend/src/pages/Following.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Card } from "@/components/ui/card";
+import { User, Ticket } from "lucide-react";
+import { apiService } from "@/lib/api";
+import type { FollowedOrganizer } from "@/types/api";
+
+const Following = () => {
+  const [list, setList] = useState<FollowedOrganizer[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    apiService
+      .getFollowing()
+      .then(setList)
+      .catch(() => setList([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen py-8">
+      <div className="container mx-auto px-4 max-w-2xl">
+        <h1 className="text-3xl font-bold mb-6">Following</h1>
+        <p className="text-muted-foreground mb-6">
+          Organizers you follow. Visit their events from event pages.
+        </p>
+        {list.length === 0 ? (
+          <Card className="p-8 text-center">
+            <User className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+            <p className="text-muted-foreground">You aren’t following any organizers yet.</p>
+            <p className="text-sm text-muted-foreground mt-2">
+              Go to an event and click <strong>Follow</strong> next to the organizer.
+            </p>
+            <Link to="/events" className="inline-block mt-4 text-primary font-medium hover:underline">
+              Discover events →
+            </Link>
+          </Card>
+        ) : (
+          <ul className="space-y-3">
+            {list.map((o) => (
+              <li key={o.organizerId}>
+                <Link
+                  to={`/events?organizerId=${o.organizerId}`}
+                  className="flex items-center gap-3 p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
+                >
+                  {o.profilePictureUrl ? (
+                    <img
+                      src={o.profilePictureUrl}
+                      alt=""
+                      className="h-12 w-12 rounded-full object-cover bg-muted"
+                    />
+                  ) : (
+                    <div className="h-12 w-12 rounded-full bg-muted flex items-center justify-center">
+                      <User className="h-6 w-6 text-muted-foreground" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <span className="font-semibold text-foreground">
+                      {[o.firstName, o.lastName].filter(Boolean).join(" ") || "Organizer"}
+                    </span>
+                  </div>
+                  <Ticket className="h-5 w-5 text-muted-foreground shrink-0" />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Following;

--- a/eventpro-frontend/src/pages/Profile.tsx
+++ b/eventpro-frontend/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -64,6 +64,8 @@ const Profile = () => {
   const [brandingPrimaryColor, setBrandingPrimaryColor] = useState(user?.brandingPrimaryColor ?? "");
   const [brandingHidePlatform, setBrandingHidePlatform] = useState(user?.brandingHidePlatform ?? false);
   const [brandingSaving, setBrandingSaving] = useState(false);
+  const [profilePhotoUploading, setProfilePhotoUploading] = useState(false);
+  const profilePhotoInputRef = useRef<HTMLInputElement>(null);
 
   const fetchSummary = useCallback(() => {
     if (!hasRole("ORGANIZER")) {
@@ -330,12 +332,43 @@ const Profile = () => {
           >
             <CardContent className="p-6 sm:p-8 flex flex-col sm:flex-row items-center gap-6">
               <div className="relative shrink-0">
+                <input
+                  ref={profilePhotoInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={async (e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+                    setProfilePhotoUploading(true);
+                    try {
+                      await apiService.uploadProfilePicture(file);
+                      await refreshUser();
+                      toast.success("Profile picture updated.");
+                    } catch (err: any) {
+                      toast.error(err?.message || "Failed to upload profile picture.");
+                    } finally {
+                      setProfilePhotoUploading(false);
+                      e.target.value = "";
+                    }
+                  }}
+                />
                 <Avatar className="h-28 w-28 ring-4 ring-primary/40 ring-offset-4 ring-offset-background shadow-lg shadow-[0_0_24px_hsl(var(--primary)_/_0.35)]">
                   <AvatarImage src={user?.profilePictureUrl} alt={displayName} />
                   <AvatarFallback className="bg-gradient-to-br from-primary to-primary-glow text-primary-foreground text-3xl">
                     {getInitials()}
                   </AvatarFallback>
                 </Avatar>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="absolute bottom-0 right-0 rounded-full h-9 w-9 p-0 shadow-md"
+                  disabled={profilePhotoUploading}
+                  onClick={() => profilePhotoInputRef.current?.click()}
+                >
+                  {profilePhotoUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <PenLine className="h-4 w-4" />}
+                </Button>
               </div>
               <div className="flex-1 text-center sm:text-left">
                 <h1 className="text-3xl sm:text-4xl font-extrabold font-heading tracking-tight text-foreground">

--- a/eventpro-frontend/src/types/api.ts
+++ b/eventpro-frontend/src/types/api.ts
@@ -49,6 +49,8 @@ export interface Event {
   title?: string;
   description?: string;
   imageUrl?: string;
+  /** Additional images for gallery (primary is imageUrl). */
+  additionalImageUrls?: string[] | null;
   /** Optional YouTube/Vimeo URL for promotional video on event detail page. */
   promotionalVideoUrl?: string;
   /** Event page template for theming. Defaults to DEFAULT. */
@@ -66,6 +68,10 @@ export interface Event {
   organizerBrandingPrimaryColor?: string | null;
   /** White-label: hide platform branding on this event page. */
   organizerBrandingHidePlatform?: boolean;
+  /** Organizer display (event detail). */
+  organizerFirstName?: string | null;
+  organizerLastName?: string | null;
+  organizerProfilePictureUrl?: string | null;
   startTime: string;
   endTime: string;
   userId?: string;
@@ -255,6 +261,14 @@ export interface PageResponse<T> {
 }
 
 /** In-app notification for the current user. */
+/** Organizer in the current user's Following list. */
+export interface FollowedOrganizer {
+  organizerId: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  profilePictureUrl?: string | null;
+}
+
 export interface UserNotification {
   id: string;
   notificationId: string;

--- a/eventpro-mobile/App.tsx
+++ b/eventpro-mobile/App.tsx
@@ -12,6 +12,7 @@ import Constants from "expo-constants";
 import { View, ActivityIndicator, StyleSheet, Linking, Alert } from "react-native";
 
 import { AuthProvider, useAuth } from "./src/context/AuthContext";
+import { CartProvider } from "./src/contexts/CartContext";
 import { NotificationPreferencesProvider } from "./src/contexts/NotificationPreferencesContext";
 import { RecentlyViewedProvider } from "./src/contexts/RecentlyViewedContext";
 import { ThemeProvider } from "./src/contexts/ThemeContext";
@@ -101,17 +102,21 @@ function AppContent() {
     []
   );
 
+  const getAccessToken = useMemo(() => () => SecureStore.getItemAsync("accessToken"), []);
+
   return (
     <ThemeProvider>
-      <AuthProvider api={api} onUnauthorizedRef={onUnauthorizedRef}>
-        <NotificationPreferencesProvider>
-          <RecentlyViewedProvider>
-            <NavigationContainer ref={navigationRef}>
+      <AuthProvider api={api} getAccessToken={getAccessToken} onUnauthorizedRef={onUnauthorizedRef}>
+        <CartProvider>
+          <NotificationPreferencesProvider>
+            <RecentlyViewedProvider>
+              <NavigationContainer ref={navigationRef}>
             <RootNavigator />
             <DeepLinkHandler navigationRef={navigationRef} />
           </NavigationContainer>
-          </RecentlyViewedProvider>
-        </NotificationPreferencesProvider>
+            </RecentlyViewedProvider>
+          </NotificationPreferencesProvider>
+        </CartProvider>
       </AuthProvider>
     </ThemeProvider>
   );
@@ -130,13 +135,11 @@ function RootNavigator() {
     );
   }
 
+  // Same flow as web: land on Discover (Main), no login prompt. Auth only when user taps Sign in or does protected action.
   return (
-    <RootStack.Navigator screenOptions={{ headerShown: false }}>
-      {!user ? (
-        <RootStack.Screen name="Auth" component={AuthStack} />
-      ) : (
-        <RootStack.Screen name="Main" component={MainTabs} />
-      )}
+    <RootStack.Navigator screenOptions={{ headerShown: false }} initialRouteName="Main">
+      <RootStack.Screen name="Main" component={MainTabs} />
+      <RootStack.Screen name="Auth" component={AuthStack} />
     </RootStack.Navigator>
   );
 }

--- a/eventpro-mobile/package.json
+++ b/eventpro-mobile/package.json
@@ -17,6 +17,7 @@
     "expo": "~54.0.0",
     "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
+    "expo-image-picker": "~16.0.3",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "jsdom": "28.1.0",

--- a/eventpro-mobile/src/components/EventCard.tsx
+++ b/eventpro-mobile/src/components/EventCard.tsx
@@ -1,0 +1,214 @@
+/**
+ * Event card matching web UI: image top (~60%), gradient overlay, category, title, date/time/venue, Get Tickets.
+ * Uses useTheme() so dark mode applies.
+ */
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet, Image } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { Event } from "@eventpro/shared";
+import { useTheme } from "../contexts/ThemeContext";
+import { useSimulatedViewers } from "../hooks/useSimulatedViewers";
+
+const CARD_IMAGE_HEIGHT = 200;
+
+function formatDate(value: string | undefined): string {
+  if (!value) return "Date TBD";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "Date TBD";
+  return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+}
+
+function formatTime(value: string | undefined): string {
+  if (!value) return "Time TBD";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "Time TBD";
+  return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+export function EventCard({
+  event,
+  onPress,
+}: {
+  event: Event;
+  onPress: () => void;
+}) {
+  const { theme } = useTheme();
+  const viewers = useSimulatedViewers(event.id, 5, 28);
+  const imageUrl = (event as any).imageUrl ?? (event as any).coverImageUrl;
+  const startRaw = event.startTime ?? (event as any).startDateTime;
+  const category = event.categoryName ?? (event as any).category;
+  const venue = (event as any).venue ?? event.addressCity;
+
+  return (
+    <TouchableOpacity
+      style={[styles.card, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}
+      onPress={onPress}
+      activeOpacity={0.9}
+    >
+      {/* Image section ~60% of card */}
+      <View style={styles.imageWrap}>
+        {imageUrl ? (
+          <Image source={{ uri: imageUrl }} style={styles.image} resizeMode="cover" />
+        ) : (
+          <View style={[styles.imagePlaceholder, { backgroundColor: theme.colors.muted }]}>
+            <Ionicons name="ticket" size={56} color={theme.colors.mutedForeground} />
+          </View>
+        )}
+        <View style={styles.imageOverlay} />
+        {category ? (
+          <View style={[styles.categoryBadge, { backgroundColor: "rgba(0,0,0,0.5)" }]}>
+            <Text style={styles.categoryText} numberOfLines={1}>{category}</Text>
+          </View>
+        ) : null}
+        <View style={[styles.viewingBadge, { backgroundColor: "rgba(0,0,0,0.4)" }]}>
+          <View style={styles.viewingBadgeDot} />
+          <Text style={styles.viewingBadgeText}>{viewers} viewing</Text>
+        </View>
+      </View>
+
+      {/* Content */}
+      <View style={styles.content}>
+        <Text style={[styles.title, { color: theme.colors.foreground }]} numberOfLines={2}>
+          {event.name || (event as any).title || "Event"}
+        </Text>
+        {event.description ? (
+          <Text style={[styles.desc, { color: theme.colors.mutedForeground }]} numberOfLines={2}>
+            {event.description}
+          </Text>
+        ) : null}
+        <View style={styles.details}>
+          <View style={styles.detailRow}>
+            <View style={[styles.detailIcon, { backgroundColor: theme.colors.primary + "20" }]}>
+              <Ionicons name="calendar-outline" size={18} color={theme.colors.primary} />
+            </View>
+            <Text style={[styles.detailText, { color: theme.colors.foreground }]}>{formatDate(startRaw)}</Text>
+          </View>
+          <View style={styles.detailRow}>
+            <View style={[styles.detailIcon, { backgroundColor: theme.colors.primary + "20" }]}>
+              <Ionicons name="time-outline" size={18} color={theme.colors.primary} />
+            </View>
+            <Text style={[styles.detailText, { color: theme.colors.foreground }]}>{formatTime(startRaw)}</Text>
+          </View>
+          {venue ? (
+            <View style={styles.detailRow}>
+              <View style={[styles.detailIcon, { backgroundColor: theme.colors.primary + "20" }]}>
+                <Ionicons name="location-outline" size={18} color={theme.colors.primary} />
+              </View>
+              <Text style={[styles.detailText, { color: theme.colors.foreground }]} numberOfLines={1}>{venue}</Text>
+            </View>
+          ) : null}
+        </View>
+        <TouchableOpacity
+          style={[styles.cta, { backgroundColor: theme.colors.primary }]}
+          onPress={onPress}
+          activeOpacity={0.85}
+        >
+          <Ionicons name="ticket-outline" size={20} color={theme.colors.primaryForeground} />
+          <Text style={[styles.ctaText, { color: theme.colors.primaryForeground }]}>Get Tickets</Text>
+        </TouchableOpacity>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    overflow: "hidden",
+    borderWidth: 1,
+    marginBottom: 20,
+  },
+  imageWrap: {
+    height: CARD_IMAGE_HEIGHT,
+    position: "relative",
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+  },
+  imagePlaceholder: {
+    width: "100%",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  imageOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "transparent",
+    borderBottomWidth: 0,
+    // gradient-like: darker at bottom for text readability (we use a simple overlay)
+    // React Native doesn't have CSS gradient; we could use expo-linear-gradient for parity
+  },
+  categoryBadge: {
+    position: "absolute",
+    top: 12,
+    left: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  categoryText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#fff",
+  },
+  viewingBadge: {
+    position: "absolute",
+    top: 12,
+    right: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 9999,
+  },
+  viewingBadgeDot: { width: 4, height: 4, borderRadius: 2, backgroundColor: "#22d3ee" },
+  viewingBadgeText: { fontSize: 11, fontWeight: "600", color: "#fff" },
+  content: {
+    padding: 18,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    marginBottom: 6,
+  },
+  desc: {
+    fontSize: 14,
+    marginBottom: 12,
+    lineHeight: 20,
+  },
+  details: {
+    gap: 10,
+    marginBottom: 16,
+  },
+  detailRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  detailIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  detailText: {
+    fontSize: 14,
+    fontWeight: "500",
+    flex: 1,
+  },
+  cta: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 14,
+    borderRadius: 12,
+  },
+  ctaText: {
+    fontSize: 16,
+    fontWeight: "700",
+  },
+});

--- a/eventpro-mobile/src/context/AuthContext.tsx
+++ b/eventpro-mobile/src/context/AuthContext.tsx
@@ -19,11 +19,13 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 type AuthProviderProps = {
   children: React.ReactNode;
   api: EventProApi;
+  /** Used to skip getCurrentUser when no token (guest-first load). */
+  getAccessToken: () => string | null | Promise<string | null>;
   /** Ref set to a function that clears user (called on 401). */
   onUnauthorizedRef?: React.MutableRefObject<(() => void) | null>;
 };
 
-export function AuthProvider({ children, api, onUnauthorizedRef }: AuthProviderProps) {
+export function AuthProvider({ children, api, getAccessToken, onUnauthorizedRef }: AuthProviderProps) {
   if (api == null) {
     throw new Error("AuthProvider requires api");
   }
@@ -77,13 +79,22 @@ export function AuthProvider({ children, api, onUnauthorizedRef }: AuthProviderP
     [user?.role]
   );
 
+  // Same flow as web: allow browsing without login. Only restore session when we have a token.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    api
-      .getCurrentUser()
+    getAccessToken()
+      .then((token) => {
+        if (cancelled) return;
+        if (!token || (typeof token === "string" && !token.trim())) {
+          setUserState(null);
+          setLoading(false);
+          return;
+        }
+        return api.getCurrentUser();
+      })
       .then((u) => {
-        if (!cancelled) setUserState(u);
+        if (!cancelled && u !== undefined) setUserState(u);
       })
       .catch(() => {
         if (!cancelled) setUserState(null);
@@ -94,7 +105,7 @@ export function AuthProvider({ children, api, onUnauthorizedRef }: AuthProviderP
     return () => {
       cancelled = true;
     };
-  }, [api]);
+  }, [api, getAccessToken]);
 
   const value: AuthContextValue = {
     user,

--- a/eventpro-mobile/src/contexts/CartContext.tsx
+++ b/eventpro-mobile/src/contexts/CartContext.tsx
@@ -1,0 +1,153 @@
+/**
+ * Mobile cart: guest (in-memory) or logged-in (API).
+ * Matches web behavior so guests can add to cart and checkout without an account.
+ */
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { useAuth } from "../context/AuthContext";
+import type { TicketTypeEnum } from "@eventpro/shared";
+
+export interface CartItem {
+  id: string;
+  ticketTypeId: string;
+  ticketTypeName: string;
+  eventName: string;
+  eventId: string;
+  quantity: number;
+  price: number;
+}
+
+type CartContextValue = {
+  items: CartItem[];
+  itemCount: number;
+  totalAmount: number;
+  isLoading: boolean;
+  addItem: (item: Omit<CartItem, "id">) => Promise<void>;
+  removeItem: (itemId: string) => Promise<void>;
+  clearCart: () => Promise<void>;
+  refreshCart: () => Promise<void>;
+};
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const { api, user } = useAuth();
+  const isAuthenticated = !!user;
+  const [items, setItems] = useState<CartItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const refreshCart = useCallback(async () => {
+    if (!isAuthenticated) {
+      // Guest cart is in-memory only; nothing to load
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const cartData = await api.getCart();
+      const mapped: CartItem[] = (cartData.tickets ?? []).map((t: { id: string; name: string; ticketType?: string; eventIdType?: string; quantity: number; price: number }) => ({
+        id: t.id,
+        ticketTypeId: t.ticketType ?? t.id,
+        ticketTypeName: t.name,
+        eventName: t.name,
+        eventId: t.eventIdType ?? "",
+        quantity: t.quantity,
+        price: Number(t.price),
+      }));
+      setItems(mapped);
+    } catch {
+      setItems([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api, isAuthenticated]);
+
+  useEffect(() => {
+    if (isAuthenticated) refreshCart();
+  }, [isAuthenticated, refreshCart]);
+
+  const addItem = useCallback(
+    async (item: Omit<CartItem, "id">) => {
+      const newItem: CartItem = {
+        ...item,
+        id: `${item.ticketTypeId}-${item.eventId}-${Date.now()}`,
+      };
+      if (!isAuthenticated) {
+        setItems((prev) => {
+          const existingIndex = prev.findIndex((i) => i.eventId === item.eventId && i.ticketTypeId === item.ticketTypeId);
+          return existingIndex >= 0
+            ? prev.map((i, idx) => (idx === existingIndex ? { ...i, quantity: i.quantity + item.quantity } : i))
+            : [...prev, newItem];
+        });
+        return;
+      }
+      setIsLoading(true);
+      try {
+        const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(item.ticketTypeId);
+        await api.addToCart(
+          isUuid
+            ? { id: item.ticketTypeId, quantity: item.quantity }
+            : { eventIdType: item.eventId, ticketType: item.ticketTypeId as TicketTypeEnum, quantity: item.quantity }
+        );
+        await refreshCart();
+      } catch (e) {
+        console.warn("Add to cart failed", e);
+        await refreshCart();
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [api, isAuthenticated, refreshCart]
+  );
+
+  const removeItem = useCallback(
+    async (itemId: string) => {
+      if (!isAuthenticated) {
+        setItems((prev) => prev.filter((i) => i.id !== itemId));
+        return;
+      }
+      try {
+        await api.removeFromCart(itemId);
+        await refreshCart();
+      } catch {
+        await refreshCart();
+      }
+    },
+    [api, isAuthenticated, refreshCart]
+  );
+
+  const clearCart = useCallback(async () => {
+    setItems([]);
+    if (isAuthenticated) {
+      try {
+        const cart = await api.getCart();
+        for (const t of cart.tickets ?? []) {
+          await api.removeFromCart(t.id);
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }, [api, isAuthenticated]);
+
+  const itemCount = items.reduce((sum, i) => sum + i.quantity, 0);
+  const totalAmount = items.reduce((sum, i) => sum + i.quantity * i.price, 0);
+
+  const value: CartContextValue = {
+    items,
+    itemCount,
+    totalAmount,
+    isLoading,
+    addItem,
+    removeItem,
+    clearCart,
+    refreshCart,
+  };
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart(): CartContextValue {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error("useCart must be used within CartProvider");
+  return ctx;
+}

--- a/eventpro-mobile/src/contexts/RecentlyViewedContext.tsx
+++ b/eventpro-mobile/src/contexts/RecentlyViewedContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useState } fr
 import * as SecureStore from "expo-secure-store";
 import type { Event } from "@eventpro/shared";
 
-const STORAGE_KEY = "eventpro_recently_viewed";
+const STORAGE_KEY = "eventpro_recently_viewed_ids";
 const MAX_RECENTLY_VIEWED = 10;
 
 type RecentlyViewedContextValue = {
@@ -16,27 +16,14 @@ const Context = createContext<RecentlyViewedContextValue | undefined>(undefined)
 export function RecentlyViewedProvider({ children }: { children: React.ReactNode }) {
   const [recentlyViewed, setRecentlyViewed] = useState<Event[]>([]);
 
-  useEffect(() => {
-    SecureStore.getItemAsync(STORAGE_KEY)
-      .then((stored) => {
-        if (!stored) return;
-        try {
-          const parsed = JSON.parse(stored) as Event[];
-          if (Array.isArray(parsed)) {
-            setRecentlyViewed(parsed);
-          }
-        } catch {
-          // ignore
-        }
-      })
-      .catch(() => {});
-  }, []);
-
+  // Persist only event IDs (small payload) to stay under SecureStore 2048-byte limit.
+  // Full recently-viewed list is in-memory only per session.
   const addRecentlyViewed = useCallback((event: Event) => {
     setRecentlyViewed((prev) => {
       const filtered = prev.filter((e) => e.id !== event.id);
       const updated = [event, ...filtered].slice(0, MAX_RECENTLY_VIEWED);
-      SecureStore.setItemAsync(STORAGE_KEY, JSON.stringify(updated)).catch(() => {});
+      const idsOnly = updated.map((e) => e.id);
+      SecureStore.setItemAsync(STORAGE_KEY, JSON.stringify(idsOnly)).catch(() => {});
       return updated;
     });
   }, []);

--- a/eventpro-mobile/src/contexts/ThemeContext.tsx
+++ b/eventpro-mobile/src/contexts/ThemeContext.tsx
@@ -22,7 +22,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     SecureStore.getItemAsync(THEME_KEY).then((stored) => {
-      const scheme = stored === "dark" || stored === "light" ? stored : "light";
+      let scheme: ColorScheme = stored === "dark" || stored === "light" ? stored : "light";
+      if (stored !== "dark" && stored !== "light") {
+        const system = Appearance.getColorScheme();
+        if (system === "dark" || system === "light") scheme = system;
+      }
       setColorSchemeState(scheme);
       if (typeof Appearance.setColorScheme === "function") {
         Appearance.setColorScheme(scheme);

--- a/eventpro-mobile/src/hooks/useSimulatedViewers.ts
+++ b/eventpro-mobile/src/hooks/useSimulatedViewers.ts
@@ -1,0 +1,29 @@
+/**
+ * Simulated "people viewing" count per event (matches web LiveAttendanceBadge vibe).
+ * Stable base derived from eventId, fluctuates slightly every ~60s.
+ */
+import { useEffect, useMemo, useState } from "react";
+
+function hashCode(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+export function useSimulatedViewers(eventId: string, min = 5, max = 28): number {
+  const base = useMemo(
+    () => min + Math.floor(((max - min + 1) * (hashCode(eventId) % 1000)) / 1000),
+    [eventId, min, max]
+  );
+  const [count, setCount] = useState(base);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      const delta = Math.floor(Math.random() * 5) - 2;
+      setCount((c) => Math.max(min, Math.min(max, c + delta)));
+    }, 60000);
+    return () => clearInterval(t);
+  }, [base, min, max]);
+
+  return count;
+}

--- a/eventpro-mobile/src/lib/mobileApi.ts
+++ b/eventpro-mobile/src/lib/mobileApi.ts
@@ -1,0 +1,124 @@
+/**
+ * Mobile-only API helpers using fetch() so upload and follow work reliably
+ * (avoids axios/FormData quirks on RN and doesn't depend on shared package build).
+ */
+import Constants from "expo-constants";
+import * as SecureStore from "expo-secure-store";
+
+const API_URL =
+  Constants.expoConfig?.extra?.apiUrl ??
+  process.env.EXPO_PUBLIC_API_URL ??
+  "http://localhost:8080";
+
+async function getToken(): Promise<string | null> {
+  return SecureStore.getItemAsync("accessToken");
+}
+
+async function authFetch(
+  path: string,
+  options: RequestInit & { skipAuth?: boolean } = {}
+): Promise<Response> {
+  const { skipAuth, ...rest } = options;
+  const headers: Record<string, string> = {
+    ...((rest.headers as Record<string, string>) ?? {}),
+  };
+  if (!skipAuth) {
+    const token = await getToken();
+    if (token) headers.Authorization = `Bearer ${token}`;
+  }
+  return fetch(`${API_URL}${path}`, { ...rest, headers });
+}
+
+/** Upload profile picture (multipart). Uses fetch so RN FormData works. */
+export async function uploadProfilePicture(asset: {
+  uri: string;
+  type?: string;
+  name?: string;
+}): Promise<string> {
+  const formData = new FormData();
+  formData.append("image", {
+    uri: asset.uri,
+    type: asset.type ?? "image/jpeg",
+    name: asset.name ?? "profile.jpg",
+  } as any);
+
+  const token = await getToken();
+  if (!token) throw new Error("Not authenticated");
+
+  const res = await fetch(`${API_URL}/api/v1/users/upload-profile-picture`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Upload failed: ${res.status}`);
+  }
+
+  const json = await res.json();
+  const url = json?.data?.url ?? json?.url;
+  if (typeof url !== "string") throw new Error("No URL in response");
+  return url;
+}
+
+export interface FollowedOrganizerItem {
+  organizerId: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  profilePictureUrl?: string | null;
+}
+
+/** List followed organizers. */
+export async function getFollowing(): Promise<FollowedOrganizerItem[]> {
+  const res = await authFetch("/api/v1/users/me/following");
+  if (!res.ok) throw new Error(`getFollowing failed: ${res.status}`);
+  const json = await res.json();
+  const data = json?.data;
+  return Array.isArray(data) ? data : [];
+}
+
+/** Follow an organizer (userId of the organizer). */
+export async function followOrganizer(organizerId: string): Promise<void> {
+  const res = await authFetch(`/api/v1/users/me/following/${organizerId}`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Follow failed: ${res.status}`);
+  }
+}
+
+/** Unfollow an organizer. */
+export async function unfollowOrganizer(organizerId: string): Promise<void> {
+  const res = await authFetch(`/api/v1/users/me/following/${organizerId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Unfollow failed: ${res.status}`);
+  }
+}
+
+/** Organizer display profile from their user profile (name, photo). Public endpoint. */
+export interface OrganizerPublicProfile {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  profilePictureUrl?: string | null;
+}
+
+/** Fetch organizer's public profile (from profile). Use to display organizer name/photo on event detail. */
+export async function getOrganizerPublicProfile(organizerId: string): Promise<OrganizerPublicProfile | null> {
+  const res = await fetch(`${API_URL}/api/v1/users/${organizerId}/public-profile`);
+  if (!res.ok) return null;
+  const json = await res.json();
+  const data = json?.data;
+  if (!data) return null;
+  return {
+    id: data.id,
+    firstName: data.firstName ?? null,
+    lastName: data.lastName ?? null,
+    profilePictureUrl: data.profilePictureUrl ?? null,
+  };
+}

--- a/eventpro-mobile/src/navigation/AdminStack.tsx
+++ b/eventpro-mobile/src/navigation/AdminStack.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { AdminStackParamList } from "./types";
+import { useTheme } from "../contexts/ThemeContext";
 import { AdminOverviewScreen } from "../screens/AdminOverviewScreen";
 import { AdminStatsScreen } from "../screens/AdminStatsScreen";
 import { AdminUsersScreen } from "../screens/AdminUsersScreen";
@@ -13,8 +14,17 @@ import { AdminSubscriptionPaymentsScreen } from "../screens/AdminSubscriptionPay
 const Stack = createNativeStackNavigator<AdminStackParamList>();
 
 export function AdminStack() {
+  const { theme } = useTheme();
   return (
-    <Stack.Navigator screenOptions={{ headerShown: true }}>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: true,
+        headerStyle: { backgroundColor: theme.colors.card },
+        headerTintColor: theme.colors.foreground,
+        headerTitleStyle: { color: theme.colors.foreground },
+        contentStyle: { backgroundColor: theme.colors.background },
+      }}
+    >
       <Stack.Screen name="AdminOverview" component={AdminOverviewScreen} options={{ title: "Admin" }} />
       <Stack.Screen name="AdminStats" component={AdminStatsScreen} options={{ title: "Platform overview" }} />
       <Stack.Screen name="AdminUsers" component={AdminUsersScreen} options={{ title: "Users" }} />

--- a/eventpro-mobile/src/navigation/AuthStack.tsx
+++ b/eventpro-mobile/src/navigation/AuthStack.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { AuthStackParamList } from "./types";
+import { useTheme } from "../contexts/ThemeContext";
 import { LoginScreen } from "../screens/LoginScreen";
 import { SignUpScreen } from "../screens/SignUpScreen";
 import { ForgotPasswordScreen } from "../screens/ForgotPasswordScreen";
@@ -10,8 +11,17 @@ import { ResetPasswordScreen } from "../screens/ResetPasswordScreen";
 const Stack = createNativeStackNavigator<AuthStackParamList>();
 
 export function AuthStack() {
+  const { theme } = useTheme();
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: theme.colors.background },
+        headerStyle: { backgroundColor: theme.colors.card },
+        headerTintColor: theme.colors.foreground,
+        headerTitleStyle: { color: theme.colors.foreground },
+      }}
+    >
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen name="SignUp" component={SignUpScreen} options={{ headerShown: true, title: "Sign up" }} />
       <Stack.Screen

--- a/eventpro-mobile/src/navigation/DiscoverStack.tsx
+++ b/eventpro-mobile/src/navigation/DiscoverStack.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { DiscoverStackParamList } from "./types";
+import { useTheme } from "../contexts/ThemeContext";
 import { HomeScreen } from "../screens/HomeScreen";
 import { EventsListScreen } from "../screens/EventsListScreen";
 import { EventDetailScreen } from "../screens/EventDetailScreen";
@@ -9,10 +10,24 @@ import { CheckoutScreen } from "../screens/CheckoutScreen";
 const Stack = createNativeStackNavigator<DiscoverStackParamList>();
 
 export function DiscoverStack() {
+  const { theme } = useTheme();
   return (
-    <Stack.Navigator screenOptions={{ headerShown: true }}>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: true,
+        headerStyle: { backgroundColor: theme.colors.card },
+        headerTintColor: theme.colors.foreground,
+        headerTitleStyle: { color: theme.colors.foreground },
+        headerShadowVisible: false,
+        contentStyle: { backgroundColor: theme.colors.background },
+      }}
+    >
       <Stack.Screen name="Home" component={HomeScreen} options={{ title: "Home" }} />
-      <Stack.Screen name="EventsList" component={EventsListScreen} options={{ title: "Events" }} />
+      <Stack.Screen
+        name="EventsList"
+        component={EventsListScreen}
+        options={({ route }) => ({ title: (route.params as { organizerId?: string })?.organizerId ? "More from this organizer" : "Events" })}
+      />
       <Stack.Screen name="EventDetail" component={EventDetailScreen} options={{ title: "Event" }} />
       <Stack.Screen name="Checkout" component={CheckoutScreen} options={{ title: "Checkout" }} />
     </Stack.Navigator>

--- a/eventpro-mobile/src/navigation/OrganizerStack.tsx
+++ b/eventpro-mobile/src/navigation/OrganizerStack.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { OrganizerStackParamList } from "./types";
+import { useTheme } from "../contexts/ThemeContext";
 import { OrganizerDashboardScreen } from "../screens/OrganizerDashboardScreen";
 import { OrganizerEventDetailScreen } from "../screens/OrganizerEventDetailScreen";
 import { EventTicketsScreen } from "../screens/EventTicketsScreen";
@@ -11,8 +12,17 @@ import { QRScannerScreen } from "../screens/QRScannerScreen";
 const Stack = createNativeStackNavigator<OrganizerStackParamList>();
 
 export function OrganizerStack() {
+  const { theme } = useTheme();
   return (
-    <Stack.Navigator screenOptions={{ headerShown: true }}>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: true,
+        headerStyle: { backgroundColor: theme.colors.card },
+        headerTintColor: theme.colors.foreground,
+        headerTitleStyle: { color: theme.colors.foreground },
+        contentStyle: { backgroundColor: theme.colors.background },
+      }}
+    >
       <Stack.Screen name="OrganizerDashboard" component={OrganizerDashboardScreen} options={{ title: "Organizer" }} />
       <Stack.Screen name="OrganizerEventDetail" component={OrganizerEventDetailScreen} options={{ title: "Event" }} />
       <Stack.Screen name="EventTickets" component={EventTicketsScreen} options={{ title: "Tickets" }} />

--- a/eventpro-mobile/src/navigation/ProfileStack.tsx
+++ b/eventpro-mobile/src/navigation/ProfileStack.tsx
@@ -8,6 +8,7 @@ import { ProfileScreen } from "../screens/ProfileScreen";
 import { ProfileEditScreen } from "../screens/ProfileEditScreen";
 import { SettingsScreen } from "../screens/SettingsScreen";
 import { OrderHistoryScreen } from "../screens/OrderHistoryScreen";
+import { FollowingScreen } from "../screens/FollowingScreen";
 import { PricingScreen } from "../screens/PricingScreen";
 import { PrivacyScreen } from "../screens/PrivacyScreen";
 import { NotificationsScreen } from "../screens/NotificationsScreen";
@@ -41,8 +42,18 @@ function ProfileHeaderRight({ navigation }: { navigation: NativeStackNavigationP
 }
 
 export function ProfileStack() {
+  const { theme } = useTheme();
   return (
-    <Stack.Navigator screenOptions={{ headerShown: true }}>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: true,
+        headerStyle: { backgroundColor: theme.colors.card },
+        headerTintColor: theme.colors.foreground,
+        headerTitleStyle: { color: theme.colors.foreground },
+        headerShadowVisible: false,
+        contentStyle: { backgroundColor: theme.colors.background },
+      }}
+    >
       <Stack.Screen
         name="ProfileHome"
         component={ProfileScreen}
@@ -56,6 +67,7 @@ export function ProfileStack() {
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: "Settings" }} />
       <Stack.Screen name="Notifications" component={NotificationsScreen} options={{ title: "Notifications" }} />
       <Stack.Screen name="OrderHistory" component={OrderHistoryScreen} options={{ title: "Orders" }} />
+      <Stack.Screen name="Following" component={FollowingScreen} options={{ title: "Following" }} />
       <Stack.Screen name="Pricing" component={PricingScreen} options={{ title: "Pricing" }} />
       <Stack.Screen name="Privacy" component={PrivacyScreen} options={{ title: "Privacy" }} />
     </Stack.Navigator>

--- a/eventpro-mobile/src/navigation/types.ts
+++ b/eventpro-mobile/src/navigation/types.ts
@@ -15,7 +15,7 @@ export type AuthStackParamList = {
 
 export type DiscoverStackParamList = {
   Home: undefined;
-  EventsList: undefined;
+  EventsList: { organizerId?: string } | undefined;
   EventDetail: { eventId: string };
   Checkout: { eventId?: string };
 };
@@ -26,6 +26,7 @@ export type ProfileStackParamList = {
   Settings: undefined;
   Notifications: undefined;
   OrderHistory: undefined;
+  Following: undefined;
   Pricing: undefined;
   Privacy: undefined;
 };

--- a/eventpro-mobile/src/screens/CheckoutScreen.tsx
+++ b/eventpro-mobile/src/screens/CheckoutScreen.tsx
@@ -8,10 +8,47 @@ import {
   ActivityIndicator,
   Alert,
   RefreshControl,
+  TextInput,
+  Linking,
 } from "react-native";
+import Constants from "expo-constants";
 import { useAuth } from "../context/AuthContext";
-import type { CartResponse, CartItemResponse, CheckoutTotals } from "@eventpro/shared";
-import { theme } from "../theme";
+import { useCart } from "../contexts/CartContext";
+import type { CheckoutTotals } from "@eventpro/shared";
+import { useTheme } from "../contexts/ThemeContext";
+import type { Theme } from "../theme";
+
+const WEB_URL = Constants.expoConfig?.extra?.webUrl ?? process.env.EXPO_PUBLIC_WEB_URL ?? "https://eventpro.com";
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    centered: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: theme.colors.background },
+    content: { padding: theme.spacing.md },
+    emptyTitle: { fontSize: 20, fontWeight: "700", marginBottom: 8, textAlign: "center", color: theme.colors.foreground },
+    emptyDesc: { fontSize: 15, marginBottom: 24, textAlign: "center", color: theme.colors.mutedForeground },
+    sectionTitle: { fontSize: 18, fontWeight: "600", marginBottom: 12, color: theme.colors.foreground },
+    row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+    rowLeft: { flex: 1 },
+    itemName: { fontSize: 16, fontWeight: "600", color: theme.colors.foreground },
+    itemMeta: { fontSize: 14, marginTop: 2, color: theme.colors.mutedForeground },
+    removeBtn: { padding: 8 },
+    removeText: { fontSize: 14, color: theme.colors.destructive },
+    totals: { marginTop: 16, paddingTop: 16, borderTopWidth: 1, borderTopColor: theme.colors.border },
+    totalRow: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 6 },
+    totalRowLast: { marginTop: 8 },
+    totalLabel: { fontSize: 15, color: theme.colors.mutedForeground },
+    totalValue: { fontSize: 15, color: theme.colors.foreground },
+    totalLabelBold: { fontSize: 17, fontWeight: "700", color: theme.colors.foreground },
+    totalValueBold: { fontSize: 17, fontWeight: "700", color: theme.colors.foreground },
+    button: { backgroundColor: theme.colors.primary, padding: 16, borderRadius: theme.radius.md, alignItems: "center", marginTop: 24 },
+    buttonDisabled: { opacity: 0.7 },
+    buttonText: { color: theme.colors.primaryForeground, fontWeight: "600" },
+    guestForm: { marginTop: 16, marginBottom: 16 },
+    guestLabel: { fontSize: 14, fontWeight: "600", marginBottom: 6, color: theme.colors.foreground },
+    guestInput: { borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.md, padding: 14, fontSize: 16, marginBottom: 12, backgroundColor: theme.colors.card, color: theme.colors.foreground },
+  });
+}
 
 export function CheckoutScreen({
   route,
@@ -20,70 +57,79 @@ export function CheckoutScreen({
   route: { params?: { eventId?: string } };
   navigation: any;
 }) {
-  const { api } = useAuth();
-  const [cart, setCart] = useState<CartResponse | null>(null);
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
+  const { api, user } = useAuth();
+  const { items: cartItems, totalAmount: cartTotal, isLoading, removeItem, refreshCart, clearCart } = useCart();
   const [totals, setTotals] = useState<CheckoutTotals | null>(null);
-  const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [paying, setPaying] = useState(false);
+  const [guestInfo, setGuestInfo] = useState<{ firstName: string; lastName: string; email: string } | null>(null);
+  const [guestForm, setGuestForm] = useState({ firstName: "", lastName: "", email: "" });
 
-  const loadCart = async () => {
-    try {
-      const data = await api.getCart();
-      setCart(data);
-      const total = data?.totalCost ?? 0;
-      if (total > 0) {
-        const t = await api.getCheckoutTotals(total).catch(() => null);
-        setTotals(t ?? null);
-      } else {
-        setTotals(null);
-      }
-    } catch {
-      setCart(null);
-      setTotals(null);
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  };
+  const isGuest = !user;
+  const subtotal = cartTotal;
+  const isEmpty = cartItems.length === 0;
 
   useEffect(() => {
-    loadCart();
-  }, []);
+    refreshCart();
+  }, [refreshCart]);
+
+  useEffect(() => {
+    if (subtotal <= 0) {
+      setTotals(null);
+      return;
+    }
+    api.getCheckoutTotals(subtotal).then(setTotals).catch(() => setTotals(null));
+  }, [api, subtotal]);
 
   const onRefresh = () => {
     setRefreshing(true);
-    loadCart();
+    refreshCart().finally(() => setRefreshing(false));
   };
 
-  const removeItem = async (ticketId: string) => {
-    try {
-      await api.removeFromCart(ticketId);
-      await loadCart();
-    } catch (e) {
-      console.error(e);
-    }
+  const canProceedAsGuest = isGuest && guestInfo === null && guestForm.firstName.trim() !== "" && guestForm.lastName.trim() !== "" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(guestForm.email.trim());
+
+  const handleContinueAsGuest = () => {
+    if (!canProceedAsGuest) return;
+    setGuestInfo({
+      firstName: guestForm.firstName.trim(),
+      lastName: guestForm.lastName.trim(),
+      email: guestForm.email.trim(),
+    });
   };
 
   const handlePay = async () => {
-    const total = totals?.total ?? cart?.totalCost ?? 0;
-    if (total <= 0) return;
+    const amountToCharge = totals?.total ?? subtotal;
+    if (amountToCharge <= 0) return;
+    const amount = Number(amountToCharge.toFixed(2));
     setPaying(true);
     try {
-      const { clientSecret } = await api.createPaymentIntent(total);
+      if (isGuest && guestInfo) {
+        const reservePayload = cartItems.map((i) => ({
+          eventId: i.eventId,
+          ticketType: i.ticketTypeId,
+          quantity: i.quantity,
+        }));
+        await api.guestReserve(reservePayload);
+      }
+      const { clientSecret } = await api.createPaymentIntent(amount);
       setPaying(false);
       Alert.alert(
         "Complete payment",
-        "In-app card entry is coming soon. For now, complete your purchase on the EventPro website, or use the same account on web to pay for the items in your cart.",
-        [{ text: "OK" }]
+        "In-app card entry is coming soon. Open the EventPro website in your browser to complete payment as a guest, or sign in on web to pay with your account.",
+        [
+          { text: "OK" },
+          ...(WEB_URL ? [{ text: "Open website", onPress: () => Linking.openURL(WEB_URL + "/checkout") }] : []),
+        ]
       );
     } catch (e) {
       setPaying(false);
-      Alert.alert("Payment error", "Could not start payment. Try again.");
+      Alert.alert("Payment error", (e as Error)?.message ?? "Could not start payment. Try again.");
     }
   };
 
-  if (loading) {
+  if (isLoading && cartItems.length === 0) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" color={theme.colors.primary} />
@@ -91,9 +137,7 @@ export function CheckoutScreen({
     );
   }
 
-  const tickets: CartItemResponse[] = cart?.tickets ?? [];
-  const isEmpty = tickets.length === 0;
-  const totalAmount = totals?.total ?? cart?.totalCost ?? 0;
+  const totalAmount = totals?.total ?? subtotal;
 
   return (
     <ScrollView
@@ -119,12 +163,12 @@ export function CheckoutScreen({
         ) : (
           <>
             <Text style={styles.sectionTitle}>Order summary</Text>
-            {tickets.map((item) => (
+            {cartItems.map((item) => (
               <View key={item.id} style={styles.row}>
                 <View style={styles.rowLeft}>
-                  <Text style={styles.itemName}>{item.name}</Text>
+                  <Text style={styles.itemName}>{item.ticketTypeName}</Text>
                   <Text style={styles.itemMeta}>
-                    {item.ticketType} · {item.quantity} × ${Number(item.price).toFixed(2)}
+                    {item.quantity} × ${Number(item.price).toFixed(2)}
                   </Text>
                 </View>
                 <TouchableOpacity
@@ -135,7 +179,45 @@ export function CheckoutScreen({
                 </TouchableOpacity>
               </View>
             ))}
-            {totals ? (
+            {isGuest && !guestInfo ? (
+              <View style={styles.guestForm}>
+                <Text style={styles.guestLabel}>Continue as guest (no account required)</Text>
+                <Text style={[styles.guestLabel, { fontSize: 12, fontWeight: "400", color: theme.colors.mutedForeground }]}>First name</Text>
+                <TextInput
+                  style={styles.guestInput}
+                  placeholder="First name"
+                  placeholderTextColor={theme.colors.mutedForeground}
+                  value={guestForm.firstName}
+                  onChangeText={(t) => setGuestForm((f) => ({ ...f, firstName: t }))}
+                />
+                <Text style={[styles.guestLabel, { fontSize: 12, fontWeight: "400", color: theme.colors.mutedForeground }]}>Last name</Text>
+                <TextInput
+                  style={styles.guestInput}
+                  placeholder="Last name"
+                  placeholderTextColor={theme.colors.mutedForeground}
+                  value={guestForm.lastName}
+                  onChangeText={(t) => setGuestForm((f) => ({ ...f, lastName: t }))}
+                />
+                <Text style={[styles.guestLabel, { fontSize: 12, fontWeight: "400", color: theme.colors.mutedForeground }]}>Email *</Text>
+                <TextInput
+                  style={styles.guestInput}
+                  placeholder="you@example.com"
+                  placeholderTextColor={theme.colors.mutedForeground}
+                  value={guestForm.email}
+                  onChangeText={(t) => setGuestForm((f) => ({ ...f, email: t }))}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                />
+                <TouchableOpacity
+                  style={[styles.button, !canProceedAsGuest && styles.buttonDisabled]}
+                  onPress={handleContinueAsGuest}
+                  disabled={!canProceedAsGuest}
+                >
+                  <Text style={styles.buttonText}>Continue as guest</Text>
+                </TouchableOpacity>
+              </View>
+            ) : null}
+            {(user || (isGuest && guestInfo)) && totals ? (
               <View style={styles.totals}>
                 <View style={styles.totalRow}>
                   <Text style={styles.totalLabel}>Subtotal</Text>
@@ -152,51 +234,28 @@ export function CheckoutScreen({
                   <Text style={styles.totalValueBold}>${totals.total.toFixed(2)}</Text>
                 </View>
               </View>
-            ) : (
+            ) : (user || (isGuest && guestInfo)) ? (
               <View style={styles.totals}>
                 <View style={[styles.totalRow, styles.totalRowLast]}>
                   <Text style={styles.totalLabelBold}>Total</Text>
                   <Text style={styles.totalValueBold}>${totalAmount.toFixed(2)}</Text>
                 </View>
               </View>
+            ) : null}
+            {(user || (isGuest && guestInfo)) && (
+              <TouchableOpacity
+                style={[styles.button, paying && styles.buttonDisabled]}
+                onPress={handlePay}
+                disabled={paying}
+              >
+                <Text style={styles.buttonText}>
+                  {paying ? "Preparing…" : "Pay now"}
+                </Text>
+              </TouchableOpacity>
             )}
-            <TouchableOpacity
-              style={[styles.button, paying && styles.buttonDisabled]}
-              onPress={handlePay}
-              disabled={paying}
-            >
-              <Text style={styles.buttonText}>
-                {paying ? "Preparing…" : "Pay now"}
-              </Text>
-            </TouchableOpacity>
           </>
         )}
       </View>
     </ScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
-  centered: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: theme.colors.background },
-  content: { padding: theme.spacing.md },
-  emptyTitle: { fontSize: 20, fontWeight: "700", marginBottom: 8, textAlign: "center", color: theme.colors.foreground },
-  emptyDesc: { fontSize: 15, marginBottom: 24, textAlign: "center", color: theme.colors.mutedForeground },
-  sectionTitle: { fontSize: 18, fontWeight: "600", marginBottom: 12, color: theme.colors.foreground },
-  row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  rowLeft: { flex: 1 },
-  itemName: { fontSize: 16, fontWeight: "600", color: theme.colors.foreground },
-  itemMeta: { fontSize: 14, marginTop: 2, color: theme.colors.mutedForeground },
-  removeBtn: { padding: 8 },
-  removeText: { fontSize: 14, color: theme.colors.destructive },
-  totals: { marginTop: 16, paddingTop: 16, borderTopWidth: 1, borderTopColor: theme.colors.border },
-  totalRow: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 6 },
-  totalRowLast: { marginTop: 8 },
-  totalLabel: { fontSize: 15, color: theme.colors.mutedForeground },
-  totalValue: { fontSize: 15, color: theme.colors.foreground },
-  totalLabelBold: { fontSize: 17, fontWeight: "700", color: theme.colors.foreground },
-  totalValueBold: { fontSize: 17, fontWeight: "700", color: theme.colors.foreground },
-  button: { backgroundColor: theme.colors.primary, padding: 16, borderRadius: theme.radius.md, alignItems: "center", marginTop: 24 },
-  buttonDisabled: { opacity: 0.7 },
-  buttonText: { color: theme.colors.primaryForeground, fontWeight: "600" },
-});

--- a/eventpro-mobile/src/screens/EventDetailScreen.tsx
+++ b/eventpro-mobile/src/screens/EventDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -8,11 +8,115 @@ import {
   ActivityIndicator,
   Image,
   TextInput,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
+  Linking,
 } from "react-native";
 import { useAuth } from "../context/AuthContext";
+import { useCart } from "../contexts/CartContext";
 import { useRecentlyViewed } from "../contexts/RecentlyViewedContext";
+import { useTheme } from "../contexts/ThemeContext";
 import type { Event, TicketType } from "@eventpro/shared";
-import { theme } from "../theme";
+import type { Theme } from "../theme";
+import * as mobileApi from "../lib/mobileApi";
+import { useSimulatedViewers } from "../hooks/useSimulatedViewers";
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    centered: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: theme.colors.background },
+    error: { padding: 24, color: theme.colors.mutedForeground },
+    cover: { width: "100%", height: 200, backgroundColor: theme.colors.muted },
+    coverPlaceholder: { width: "100%", height: 200, backgroundColor: theme.colors.muted, justifyContent: "center", alignItems: "center" },
+    coverPlaceholderText: { color: theme.colors.mutedForeground },
+    galleryThumbs: { flexGrow: 0, paddingHorizontal: theme.spacing.md, paddingVertical: 8, gap: 8 },
+    galleryThumb: { width: 56, height: 56, borderRadius: 8, overflow: "hidden", marginRight: 8, borderWidth: 2, borderColor: "transparent" },
+    galleryThumbActive: { borderColor: theme.colors.primary },
+    galleryThumbImg: { width: "100%", height: "100%" },
+    content: { padding: theme.spacing.md },
+    title: { fontSize: 22, fontWeight: "700", marginBottom: 8, color: theme.colors.foreground },
+    desc: { fontSize: 15, marginBottom: 12, color: theme.colors.mutedForeground },
+    meta: { fontSize: 14, marginBottom: 8, color: theme.colors.mutedForeground },
+    videoCta: { paddingVertical: 12, paddingHorizontal: 16, borderRadius: theme.radius.md, alignItems: "center", marginTop: 12, marginBottom: 8 },
+    videoCtaText: { fontSize: 15, fontWeight: "600" },
+    organizerRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      marginTop: 16,
+      marginBottom: 8,
+      paddingVertical: 12,
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.border,
+    },
+    organizerAvatar: { width: 44, height: 44, borderRadius: 22, backgroundColor: theme.colors.muted },
+    organizerAvatarPlaceholder: { justifyContent: "center", alignItems: "center" },
+    organizerAvatarText: { fontSize: 16, fontWeight: "600", color: theme.colors.mutedForeground },
+    organizerInfo: { marginLeft: 12, flex: 1 },
+    organizerLabel: { fontSize: 12, color: theme.colors.mutedForeground, marginBottom: 2 },
+    organizerName: { fontSize: 16, fontWeight: "600", color: theme.colors.foreground },
+    followBtn: { paddingVertical: 8, paddingHorizontal: 14, borderRadius: theme.radius.md, borderWidth: 1, borderColor: theme.colors.border, backgroundColor: "transparent" },
+    followBtnActive: { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
+    followBtnText: { fontSize: 14, fontWeight: "600", color: theme.colors.foreground },
+    followBtnTextActive: { color: theme.colors.primaryForeground },
+    contactOrganizerBtn: { paddingVertical: 8, paddingHorizontal: 14, borderRadius: theme.radius.md, borderWidth: 1, borderColor: theme.colors.border, borderStyle: "dashed" },
+    contactOrganizerBtnText: { fontSize: 14, fontWeight: "500", color: theme.colors.foreground },
+    modalOverlay: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: "rgba(0,0,0,0.5)" },
+    modalContent: { width: "90%", maxWidth: 400, borderRadius: theme.radius.lg, padding: 24 },
+    modalTitle: { fontSize: 20, fontWeight: "700", marginBottom: 16 },
+    modalSent: { marginBottom: 20 },
+    inputLabel: { fontSize: 14, fontWeight: "500", marginBottom: 6 },
+    contactInput: { borderWidth: 1, borderRadius: theme.radius.md, paddingHorizontal: 12, paddingVertical: 10, fontSize: 16, marginBottom: 12 },
+    contactMessageInput: { minHeight: 100, textAlignVertical: "top" },
+    modalButtons: { flexDirection: "row", justifyContent: "flex-end", gap: 12, marginTop: 16 },
+    modalCloseBtn: { paddingVertical: 8 },
+    contactSubmitBtn: { paddingVertical: 10, paddingHorizontal: 20, borderRadius: theme.radius.md },
+    contactSubmitText: { fontWeight: "600" },
+    modalCancelText: { fontSize: 15 },
+    sectionTitle: { fontSize: 18, fontWeight: "600", marginTop: 20, marginBottom: 12, color: theme.colors.foreground },
+    muted: { marginBottom: 16, color: theme.colors.mutedForeground },
+    ticketRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.border,
+    },
+    ticketInfo: { flex: 1 },
+    ticketName: { fontSize: 16, fontWeight: "600", color: theme.colors.foreground },
+    ticketMeta: { fontSize: 14, marginTop: 2, color: theme.colors.mutedForeground },
+    stepper: { flexDirection: "row", alignItems: "center" },
+    stepperBtn: { width: 36, height: 36, borderRadius: 18, backgroundColor: theme.colors.muted, justifyContent: "center", alignItems: "center" },
+    stepperText: { fontSize: 18, fontWeight: "600", color: theme.colors.foreground },
+    stepperInput: { width: 40, textAlign: "center", fontSize: 16, marginHorizontal: 8, color: theme.colors.foreground },
+    button: { backgroundColor: theme.colors.primary, padding: 16, borderRadius: theme.radius.md, alignItems: "center", marginTop: 24 },
+    buttonDisabled: { backgroundColor: theme.colors.muted },
+    buttonText: { color: theme.colors.primaryForeground, fontWeight: "600" },
+    moreFromOrganizer: { marginTop: 28, paddingTop: 20, borderTopWidth: 1, borderTopColor: theme.colors.border },
+    horizontalList: { marginHorizontal: -theme.spacing.md, marginTop: 12 },
+    otherEventCard: { width: 140, marginLeft: theme.spacing.md, backgroundColor: theme.colors.card, borderRadius: theme.radius.md, overflow: "hidden", borderWidth: 1, borderColor: theme.colors.border },
+    otherEventImage: { width: 140, height: 88, backgroundColor: theme.colors.muted },
+    otherEventName: { padding: 8, fontSize: 13, fontWeight: "600", color: theme.colors.foreground },
+    viewAllLink: { marginTop: 12, paddingVertical: 8 },
+    viewAllLinkText: { fontSize: 14, color: theme.colors.primary, fontWeight: "500" },
+    liveBadge: {
+      flexDirection: "row",
+      alignItems: "center",
+      alignSelf: "flex-start",
+      gap: 6,
+      paddingHorizontal: 10,
+      paddingVertical: 6,
+      borderRadius: 9999,
+      borderWidth: 1,
+      borderColor: "rgba(255,255,255,0.3)",
+      backgroundColor: "rgba(0,0,0,0.25)",
+      marginBottom: 12,
+    },
+    liveBadgeDot: { width: 6, height: 6, borderRadius: 3, backgroundColor: "#22d3ee" },
+    liveBadgeText: { fontSize: 12, fontWeight: "600", color: theme.colors.foreground },
+  });
+}
 
 export function EventDetailScreen({
   route,
@@ -21,10 +125,23 @@ export function EventDetailScreen({
   route: { params: { eventId: string } };
   navigation: any;
 }) {
-  const { api } = useAuth();
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { api, user } = useAuth();
+  const { addItem: addToCart } = useCart();
+  const viewers = useSimulatedViewers(route.params.eventId, 8, 32);
   const { addRecentlyViewed } = useRecentlyViewed();
   const [event, setEvent] = useState<Event | null>(null);
   const [ticketTypes, setTicketTypes] = useState<TicketType[]>([]);
+  const [otherEventsByOrganizer, setOtherEventsByOrganizer] = useState<Event[]>([]);
+  const [contactModalVisible, setContactModalVisible] = useState(false);
+  const [contactForm, setContactForm] = useState({ senderName: "", senderEmail: "", message: "" });
+  const [contactSubmitting, setContactSubmitting] = useState(false);
+  const [contactSent, setContactSent] = useState(false);
+  const [followedOrganizerIds, setFollowedOrganizerIds] = useState<Set<string>>(new Set());
+  const [followLoading, setFollowLoading] = useState(false);
+  const [organizerProfile, setOrganizerProfile] = useState<mobileApi.OrganizerPublicProfile | null>(null);
+  const [galleryIndex, setGalleryIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [adding, setAdding] = useState(false);
   const [quantities, setQuantities] = useState<Record<string, number>>({});
@@ -56,6 +173,49 @@ export function EventDetailScreen({
     };
   }, [api, route.params.eventId, addRecentlyViewed]);
 
+  useEffect(() => {
+    if (!event?.userId || !route.params.eventId) return;
+    api
+      .getEvents(1, 6, undefined, event.userId)
+      .then((list) => setOtherEventsByOrganizer(list.filter((e) => e.id !== route.params.eventId)))
+      .catch(() => setOtherEventsByOrganizer([]));
+  }, [api, event?.userId, route.params.eventId]);
+
+  // Load followed organizers only when user is logged in (API requires auth)
+  useEffect(() => {
+    if (!user || !event?.userId) return;
+    mobileApi
+      .getFollowing()
+      .then((list) => {
+        const ids = new Set<string>(
+          list.map((o) => String((o as { organizerId?: string }).organizerId ?? (o as { id?: string }).id ?? "")).filter(Boolean)
+        );
+        setFollowedOrganizerIds(ids);
+      })
+      .catch(() => setFollowedOrganizerIds(new Set()));
+  }, [user, event?.userId]);
+
+  // Retrieve organizer display info from their profile (name, photo)
+  useEffect(() => {
+    if (!event?.userId) {
+      setOrganizerProfile(null);
+      return;
+    }
+    mobileApi
+      .getOrganizerPublicProfile(event.userId)
+      .then(setOrganizerProfile)
+      .catch(() => setOrganizerProfile(null));
+  }, [event?.userId]);
+
+  useEffect(() => {
+    setGalleryIndex(0);
+  }, [event?.id]);
+
+  const organizerFirstName = organizerProfile?.firstName ?? event?.organizerFirstName ?? null;
+  const organizerLastName = organizerProfile?.lastName ?? event?.organizerLastName ?? null;
+  const organizerProfilePictureUrl = organizerProfile?.profilePictureUrl ?? event?.organizerProfilePictureUrl ?? null;
+  const organizerDisplayName = [organizerFirstName, organizerLastName].filter(Boolean).join(" ").trim() || "Event organizer";
+
   const setQty = (ticketId: string, delta: number) => {
     const t = ticketTypes.find((x) => x.id === ticketId);
     if (!t) return;
@@ -80,15 +240,14 @@ export function EventDetailScreen({
       for (const t of ticketTypes) {
         const qty = quantities[t.id] ?? 0;
         if (qty > 0) {
-          if (isUuid(t.id)) {
-            await api.addToCart({ id: t.id, quantity: qty });
-          } else {
-            await api.addToCart({
-              eventIdType: event.id,
-              ticketType: t.id as "VIP" | "REGULAR" | "EARLY_BIRD",
-              quantity: qty,
-            });
-          }
+          await addToCart({
+            ticketTypeId: t.id,
+            ticketTypeName: t.name,
+            eventName: event.name,
+            eventId: event.id,
+            quantity: qty,
+            price: Number(t.price),
+          });
         }
       }
       navigation.navigate("Checkout", { eventId: event.id });
@@ -114,7 +273,11 @@ export function EventDetailScreen({
     );
   }
 
-  const imageUrl = (event as any).imageUrl ?? (event as any).coverImageUrl;
+  const mainImageUrl = (event as any).imageUrl ?? (event as any).coverImageUrl;
+  const additionalUrls = (event as any).additionalImageUrls ?? [];
+  const galleryImages = mainImageUrl ? [mainImageUrl, ...additionalUrls] : [...additionalUrls];
+  const showGallery = galleryImages.length > 1;
+  const imageUrl = galleryImages[galleryIndex] ?? mainImageUrl;
   const startTime = event.startTime ?? (event as any).startDateTime;
 
   return (
@@ -126,6 +289,15 @@ export function EventDetailScreen({
           <Text style={styles.coverPlaceholderText}>No image</Text>
         </View>
       )}
+      {showGallery && galleryImages.length > 0 ? (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.galleryThumbs}>
+          {galleryImages.map((url, i) => (
+            <TouchableOpacity key={url + i} onPress={() => setGalleryIndex(i)} style={[styles.galleryThumb, i === galleryIndex && styles.galleryThumbActive]}>
+              <Image source={{ uri: url }} style={styles.galleryThumbImg} />
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      ) : null}
       <View style={styles.content}>
         <Text style={styles.title}>{event.name}</Text>
         {event.description ? (
@@ -144,6 +316,173 @@ export function EventDetailScreen({
         {(event as any).venue ? (
           <Text style={styles.meta}>{(event as any).venue}</Text>
         ) : null}
+
+        {/* Live viewing badge (matches web) */}
+        <View style={[styles.liveBadge, { borderColor: theme.colors.border, backgroundColor: theme.colors.muted + "99" }]}>
+          <View style={styles.liveBadgeDot} />
+          <Text style={[styles.liveBadgeText, { color: theme.colors.foreground }]}>{viewers} people viewing now</Text>
+        </View>
+
+        {/* Promotional video */}
+        {event.promotionalVideoUrl ? (
+          <TouchableOpacity
+            style={[styles.videoCta, { backgroundColor: theme.colors.primary }]}
+            onPress={() => Linking.openURL(event.promotionalVideoUrl!)}
+          >
+            <Text style={[styles.videoCtaText, { color: theme.colors.primaryForeground }]}>Watch promotional video</Text>
+          </TouchableOpacity>
+        ) : null}
+
+        {/* Organizer — name and avatar (from organizer's profile when available) */}
+        {(event.userId || organizerFirstName || organizerLastName) ? (
+          <View style={styles.organizerRow}>
+            {organizerProfilePictureUrl ? (
+              <Image
+                source={{ uri: organizerProfilePictureUrl }}
+                style={styles.organizerAvatar}
+              />
+            ) : (
+              <View style={[styles.organizerAvatar, styles.organizerAvatarPlaceholder]}>
+                <Text style={styles.organizerAvatarText}>
+                  {[organizerFirstName, organizerLastName]
+                    .filter(Boolean)
+                    .map((s) => (s ?? "").charAt(0))
+                    .join("") || "?"}
+                </Text>
+              </View>
+            )}
+            <View style={styles.organizerInfo}>
+              <Text style={styles.organizerLabel}>Organized by</Text>
+              <Text style={styles.organizerName}>
+                {organizerDisplayName}
+              </Text>
+            </View>
+            <TouchableOpacity
+              style={[
+                styles.followBtn,
+                followedOrganizerIds.has(event.userId) && styles.followBtnActive,
+                followLoading && styles.buttonDisabled,
+              ]}
+              disabled={followLoading}
+              onPress={async () => {
+                if (!event.userId) return;
+                if (!user) {
+                  (navigation as any).getParent()?.getParent()?.navigate("Auth", { screen: "Login" });
+                  return;
+                }
+                setFollowLoading(true);
+                try {
+                  const organizerId = String(event.userId);
+                  if (followedOrganizerIds.has(organizerId)) {
+                    await mobileApi.unfollowOrganizer(organizerId);
+                    setFollowedOrganizerIds((s) => { const n = new Set(s); n.delete(organizerId); return n; });
+                  } else {
+                    await mobileApi.followOrganizer(organizerId);
+                    setFollowedOrganizerIds((s) => new Set(s).add(organizerId));
+                  }
+                  // Refetch to stay in sync with backend
+                  const list = await mobileApi.getFollowing();
+                  const ids = new Set<string>(list.map((o) => String((o as { organizerId?: string }).organizerId ?? (o as { id?: string }).id ?? "")).filter(Boolean));
+                  setFollowedOrganizerIds(ids);
+                } catch (e) {
+                  console.warn("Follow/unfollow failed", e);
+                } finally {
+                  setFollowLoading(false);
+                }
+              }}
+            >
+              <Text style={[styles.followBtnText, followedOrganizerIds.has(event.userId) && styles.followBtnTextActive]}>
+                {followLoading ? "…" : followedOrganizerIds.has(event.userId) ? "Followed" : "Follow"}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.contactOrganizerBtn}
+              onPress={() => { setContactModalVisible(true); setContactSent(false); setContactForm({ senderName: "", senderEmail: "", message: "" }); }}
+            >
+              <Text style={styles.contactOrganizerBtnText}>Contact organizer</Text>
+            </TouchableOpacity>
+          </View>
+        ) : null}
+
+        {/* Contact organizer modal */}
+        <Modal visible={contactModalVisible} animationType="slide" transparent>
+          <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined} style={styles.modalOverlay}>
+            <View style={[styles.modalContent, { backgroundColor: theme.colors.background }]}>
+              <Text style={[styles.modalTitle, { color: theme.colors.foreground }]}>Contact organizer</Text>
+              {contactSent ? (
+                <>
+                  <Text style={[styles.modalSent, { color: theme.colors.mutedForeground }]}>
+                    Your message has been sent. The organizer will get back to you by email.
+                  </Text>
+                  <TouchableOpacity style={styles.modalCloseBtn} onPress={() => setContactModalVisible(false)}>
+                    <Text style={styles.viewAllLinkText}>Close</Text>
+                  </TouchableOpacity>
+                </>
+              ) : (
+                <>
+                  <Text style={[styles.inputLabel, { color: theme.colors.foreground }]}>Your name (optional)</Text>
+                  <TextInput
+                    style={[styles.contactInput, { backgroundColor: theme.colors.background, borderColor: theme.colors.border, color: theme.colors.foreground }]}
+                    value={contactForm.senderName}
+                    onChangeText={(t) => setContactForm((f) => ({ ...f, senderName: t }))}
+                    placeholder="Jane Doe"
+                    placeholderTextColor={theme.colors.mutedForeground}
+                    maxLength={200}
+                  />
+                  <Text style={[styles.inputLabel, { color: theme.colors.foreground }]}>Your email *</Text>
+                  <TextInput
+                    style={[styles.contactInput, { backgroundColor: theme.colors.background, borderColor: theme.colors.border, color: theme.colors.foreground }]}
+                    value={contactForm.senderEmail}
+                    onChangeText={(t) => setContactForm((f) => ({ ...f, senderEmail: t }))}
+                    placeholder="you@example.com"
+                    placeholderTextColor={theme.colors.mutedForeground}
+                    keyboardType="email-address"
+                    autoCapitalize="none"
+                  />
+                  <Text style={[styles.inputLabel, { color: theme.colors.foreground }]}>Message *</Text>
+                  <TextInput
+                    style={[styles.contactInput, styles.contactMessageInput, { backgroundColor: theme.colors.background, borderColor: theme.colors.border, color: theme.colors.foreground }]}
+                    value={contactForm.message}
+                    onChangeText={(t) => setContactForm((f) => ({ ...f, message: t }))}
+                    placeholder="Your message to the organizer..."
+                    placeholderTextColor={theme.colors.mutedForeground}
+                    multiline
+                    maxLength={2000}
+                  />
+                  <View style={styles.modalButtons}>
+                    <TouchableOpacity style={styles.modalCloseBtn} onPress={() => setContactModalVisible(false)}>
+                      <Text style={[styles.modalCancelText, { color: theme.colors.mutedForeground }]}>Cancel</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[styles.contactSubmitBtn, { backgroundColor: theme.colors.primary }]}
+                      disabled={contactSubmitting || !contactForm.senderEmail.trim() || !contactForm.message.trim()}
+                      onPress={async () => {
+                        if (!event?.id || !contactForm.senderEmail.trim() || !contactForm.message.trim()) return;
+                        setContactSubmitting(true);
+                        try {
+                          await api.contactOrganizer(event.id, {
+                            senderEmail: contactForm.senderEmail.trim(),
+                            senderName: contactForm.senderName.trim() || undefined,
+                            message: contactForm.message.trim(),
+                          });
+                          setContactSent(true);
+                        } catch (e) {
+                          console.error(e);
+                        } finally {
+                          setContactSubmitting(false);
+                        }
+                      }}
+                    >
+                      <Text style={[styles.contactSubmitText, { color: theme.colors.primaryForeground }]}>
+                        {contactSubmitting ? "Sending…" : "Send message"}
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                </>
+              )}
+            </View>
+          </KeyboardAvoidingView>
+        </Modal>
 
         <Text style={styles.sectionTitle}>Tickets</Text>
         {ticketTypes.length === 0 ? (
@@ -194,40 +533,35 @@ export function EventDetailScreen({
             {adding ? "Adding…" : canAddToCart ? "Add to cart & continue" : "Select tickets"}
           </Text>
         </TouchableOpacity>
+
+        {/* More from this organizer */}
+        {event.userId && otherEventsByOrganizer.length > 0 ? (
+          <View style={styles.moreFromOrganizer}>
+            <Text style={styles.sectionTitle}>More from this organizer</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.horizontalList}>
+              {otherEventsByOrganizer.slice(0, 5).map((e) => (
+                <TouchableOpacity
+                  key={e.id}
+                  style={styles.otherEventCard}
+                  onPress={() => navigation.navigate("EventDetail", { eventId: e.id })}
+                >
+                  <Image
+                    source={{ uri: (e as any).imageUrl ?? (e as any).coverImageUrl ?? "" }}
+                    style={styles.otherEventImage}
+                  />
+                  <Text style={styles.otherEventName} numberOfLines={2}>{e.name}</Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            <TouchableOpacity
+              onPress={() => navigation.navigate("EventsList", { organizerId: event.userId })}
+              style={styles.viewAllLink}
+            >
+              <Text style={styles.viewAllLinkText}>View all events by this organizer →</Text>
+            </TouchableOpacity>
+          </View>
+        ) : null}
       </View>
     </ScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
-  centered: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: theme.colors.background },
-  error: { padding: 24, color: theme.colors.mutedForeground },
-  cover: { width: "100%", height: 200, backgroundColor: theme.colors.muted },
-  coverPlaceholder: { width: "100%", height: 200, backgroundColor: theme.colors.muted, justifyContent: "center", alignItems: "center" },
-  coverPlaceholderText: { color: theme.colors.mutedForeground },
-  content: { padding: theme.spacing.md },
-  title: { fontSize: 22, fontWeight: "700", marginBottom: 8, color: theme.colors.foreground },
-  desc: { fontSize: 15, marginBottom: 12, color: theme.colors.mutedForeground },
-  meta: { fontSize: 14, marginBottom: 8, color: theme.colors.mutedForeground },
-  sectionTitle: { fontSize: 18, fontWeight: "600", marginTop: 20, marginBottom: 12, color: theme.colors.foreground },
-  muted: { marginBottom: 16, color: theme.colors.mutedForeground },
-  ticketRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-  },
-  ticketInfo: { flex: 1 },
-  ticketName: { fontSize: 16, fontWeight: "600", color: theme.colors.foreground },
-  ticketMeta: { fontSize: 14, marginTop: 2, color: theme.colors.mutedForeground },
-  stepper: { flexDirection: "row", alignItems: "center" },
-  stepperBtn: { width: 36, height: 36, borderRadius: 18, backgroundColor: theme.colors.muted, justifyContent: "center", alignItems: "center" },
-  stepperText: { fontSize: 18, fontWeight: "600", color: theme.colors.foreground },
-  stepperInput: { width: 40, textAlign: "center", fontSize: 16, marginHorizontal: 8, color: theme.colors.foreground },
-  button: { backgroundColor: theme.colors.primary, padding: 16, borderRadius: theme.radius.md, alignItems: "center", marginTop: 24 },
-  buttonDisabled: { backgroundColor: theme.colors.muted },
-  buttonText: { color: theme.colors.primaryForeground, fontWeight: "600" },
-});

--- a/eventpro-mobile/src/screens/EventTicketsScreen.tsx
+++ b/eventpro-mobile/src/screens/EventTicketsScreen.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from "react";
 import { View, Text, FlatList, StyleSheet, ActivityIndicator, RefreshControl } from "react-native";
 import { useAuth } from "../context/AuthContext";
 import type { TicketType } from "@eventpro/shared";
-import { theme } from "../theme";
+import { useTheme } from "../contexts/ThemeContext";
+import { theme as staticTheme } from "../theme";
 
 export function EventTicketsScreen({ route }: { route: { params: { eventId: string } }; navigation?: any }) {
+  const { theme } = useTheme();
   const { api } = useAuth();
   const [tickets, setTickets] = useState<TicketType[]>([]);
   const [loading, setLoading] = useState(true);
@@ -83,13 +85,13 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   centered: { flex: 1, justifyContent: "center", alignItems: "center" },
   hint: { fontSize: 13, padding: 16, paddingBottom: 8 },
-  list: { padding: theme.spacing.md, paddingTop: 0 },
-  emptyList: { flexGrow: 1, padding: theme.spacing.md },
+  list: { padding: staticTheme.spacing.md, paddingTop: 0 },
+  emptyList: { flexGrow: 1, padding: staticTheme.spacing.md },
   empty: { textAlign: "center", marginTop: 24 },
-  card: { padding: 16, borderRadius: theme.radius.lg, marginBottom: 12, borderWidth: 1 },
+  card: { padding: 16, borderRadius: staticTheme.radius.lg, marginBottom: 12, borderWidth: 1 },
   cardRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
   name: { fontSize: 17, fontWeight: "600" },
-  badge: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: theme.radius.md },
+  badge: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: staticTheme.radius.md },
   badgeText: { fontSize: 12, fontWeight: "600", color: "#fff" },
   price: { fontSize: 18, fontWeight: "700", marginTop: 6 },
   meta: { fontSize: 14, marginTop: 4 },

--- a/eventpro-mobile/src/screens/EventsListScreen.tsx
+++ b/eventpro-mobile/src/screens/EventsListScreen.tsx
@@ -1,38 +1,161 @@
-import React, { useEffect, useState } from "react";
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator } from "react-native";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  RefreshControl,
+  TextInput,
+  ScrollView,
+} from "react-native";
 import { useAuth } from "../context/AuthContext";
 import type { Event } from "@eventpro/shared";
-import { theme } from "../theme";
+import { useTheme } from "../contexts/ThemeContext";
+import { EventCard } from "../components/EventCard";
+import { theme as staticTheme } from "../theme";
+import { Ionicons } from "@expo/vector-icons";
 
-export function EventsListScreen({ navigation }: { navigation: any }) {
+const EVENT_CATEGORIES = [
+  "Music", "Sports", "Technology", "Business", "Arts",
+  "Food & Drink", "Health & Wellness", "Education", "Entertainment", "Other",
+];
+
+export function EventsListScreen({ route, navigation }: { route: any; navigation: any }) {
   const { api } = useAuth();
+  const { theme } = useTheme();
+  const organizerId = route?.params?.organizerId;
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [keyword, setKeyword] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
+
+  const loadEvents = useCallback(async () => {
+    try {
+      let list: Event[];
+      if (selectedCategory) {
+        list = await api.getEventsByCategory(selectedCategory);
+      } else {
+        list = await api.getEvents(1, 30, searchQuery.trim() || undefined, organizerId);
+      }
+      setEvents(Array.isArray(list) ? list : []);
+    } catch {
+      setEvents([]);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [api, organizerId, searchQuery, selectedCategory]);
 
   useEffect(() => {
-    api
-      .getEvents(1, 20)
-      .then(setEvents)
-      .catch(() => setEvents([]))
-      .finally(() => setLoading(false));
-  }, [api]);
+    setLoading(true);
+    loadEvents();
+  }, [loadEvents]);
 
-  if (loading) return <View style={[styles.centered, { backgroundColor: theme.colors.background }]}><ActivityIndicator color={theme.colors.primary} /></View>;
+  const runSearch = () => {
+    setSearchQuery(keyword);
+    setLoading(true);
+  };
+
+  const clearFilters = () => {
+    setSelectedCategory(undefined);
+    setSearchQuery("");
+    setKeyword("");
+    setLoading(true);
+  };
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    loadEvents();
+  };
+
+  if (loading && events.length === 0) {
+    return (
+      <View style={[styles.centered, { backgroundColor: theme.colors.background }]}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      {!organizerId && (
+        <>
+          <View style={[styles.searchWrap, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}>
+            <Ionicons name="search" size={20} color={theme.colors.mutedForeground} />
+            <TextInput
+              style={[styles.searchInput, { color: theme.colors.foreground }]}
+              placeholder="Search events..."
+              placeholderTextColor={theme.colors.mutedForeground}
+              value={keyword}
+              onChangeText={setKeyword}
+              returnKeyType="search"
+              onSubmitEditing={runSearch}
+              editable={!selectedCategory}
+            />
+            {(keyword.length > 0 || selectedCategory) && (
+              <TouchableOpacity onPress={clearFilters}>
+                <Ionicons name="close-circle" size={20} color={theme.colors.mutedForeground} />
+              </TouchableOpacity>
+            )}
+          </View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.categoryScroll}
+            style={styles.categoryScrollWrap}
+          >
+            <TouchableOpacity
+              style={[
+                styles.categoryPill,
+                { borderColor: theme.colors.border, backgroundColor: selectedCategory === undefined ? theme.colors.primary : theme.colors.card },
+              ]}
+              onPress={() => { setSelectedCategory(undefined); setLoading(true); }}
+            >
+              <Text style={[styles.categoryPillText, { color: selectedCategory === undefined ? theme.colors.primaryForeground : theme.colors.foreground }]}>All</Text>
+            </TouchableOpacity>
+            {EVENT_CATEGORIES.map((cat) => {
+              const isSelected = selectedCategory === cat;
+              return (
+                <TouchableOpacity
+                  key={cat}
+                  style={[
+                    styles.categoryPill,
+                    { borderColor: theme.colors.border, backgroundColor: isSelected ? theme.colors.primary : theme.colors.card },
+                  ]}
+                  onPress={() => { setSelectedCategory(isSelected ? undefined : cat); setLoading(true); }}
+                >
+                  <Text style={[styles.categoryPillText, { color: isSelected ? theme.colors.primaryForeground : theme.colors.foreground }]}>{cat}</Text>
+                </TouchableOpacity>
+              );
+            })}
+          </ScrollView>
+        </>
+      )}
       <FlatList
         data={events}
         keyExtractor={(item) => item.id}
-        ListEmptyComponent={<Text style={[styles.empty, { color: theme.colors.mutedForeground }]}>No events right now.</Text>}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.primary} />
+        }
+        ListEmptyComponent={
+          <View style={[styles.empty, { backgroundColor: theme.colors.muted }]}>
+            <Ionicons name="calendar-outline" size={48} color={theme.colors.mutedForeground} />
+            <Text style={[styles.emptyTitle, { color: theme.colors.foreground }]}>No events found</Text>
+            <Text style={[styles.emptyDesc, { color: theme.colors.mutedForeground }]}>
+              {keyword ? "Try a different search." : "Check back later for new events."}
+            </Text>
+          </View>
+        }
         renderItem={({ item }) => (
-          <TouchableOpacity
-            style={[styles.card, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}
+          <EventCard
+            event={item}
             onPress={() => navigation.navigate("EventDetail", { eventId: item.id })}
-          >
-            <Text style={[styles.title, { color: theme.colors.foreground }]}>{item.name}</Text>
-            <Text style={[styles.meta, { color: theme.colors.mutedForeground }]}>{item.startTime ? new Date(item.startTime).toLocaleDateString() : ""}</Text>
-          </TouchableOpacity>
+          />
         )}
       />
     </View>
@@ -40,10 +163,37 @@ export function EventsListScreen({ navigation }: { navigation: any }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: theme.spacing.md },
+  container: { flex: 1 },
   centered: { flex: 1, justifyContent: "center", alignItems: "center" },
-  empty: { textAlign: "center", marginTop: 24 },
-  card: { padding: 16, borderRadius: theme.radius.lg, marginBottom: 12, borderWidth: 1 },
-  title: { fontSize: 17, fontWeight: "600" },
-  meta: { fontSize: 13, marginTop: 4 },
+  searchWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginHorizontal: staticTheme.spacing.md,
+    marginBottom: staticTheme.spacing.sm,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: staticTheme.radius.lg,
+    borderWidth: 1,
+    gap: 8,
+  },
+  searchInput: { flex: 1, fontSize: 16, paddingVertical: 4 },
+  categoryScroll: { paddingHorizontal: staticTheme.spacing.md, paddingBottom: staticTheme.spacing.sm, gap: 8, flexDirection: "row" },
+  categoryScrollWrap: { maxHeight: 44 },
+  categoryPill: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginRight: 8,
+  },
+  categoryPillText: { fontSize: 14, fontWeight: "600" },
+  listContent: { padding: staticTheme.spacing.md, paddingBottom: 32 },
+  empty: {
+    padding: 32,
+    borderRadius: staticTheme.radius.lg,
+    alignItems: "center",
+    marginTop: 24,
+  },
+  emptyTitle: { fontSize: 18, fontWeight: "600", marginTop: 12 },
+  emptyDesc: { fontSize: 14, marginTop: 4, textAlign: "center" },
 });

--- a/eventpro-mobile/src/screens/FollowingScreen.tsx
+++ b/eventpro-mobile/src/screens/FollowingScreen.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator, Image } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
+import { theme as staticTheme } from "../theme";
+import type { FollowedOrganizerItem } from "../lib/mobileApi";
+import * as mobileApi from "../lib/mobileApi";
+
+export function FollowingScreen({ navigation }: { navigation: any }) {
+  const { theme } = useTheme();
+  const [list, setList] = useState<FollowedOrganizerItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    mobileApi
+      .getFollowing()
+      .then(setList)
+      .catch(() => setList([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={[styles.centered, { backgroundColor: theme.colors.background }]}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  if (list.length === 0) {
+    return (
+      <View style={[styles.centered, styles.empty, { backgroundColor: theme.colors.background }]}>
+        <Text style={[styles.emptyTitle, { color: theme.colors.foreground }]}>Not following anyone yet</Text>
+        <Text style={[styles.emptyDesc, { color: theme.colors.mutedForeground }]}>
+          Go to an event and tap Follow next to the organizer.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <FlatList
+        data={list}
+        keyExtractor={(item) => item.organizerId}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={[styles.row, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}
+            onPress={() => navigation.getParent()?.navigate("Discover", { screen: "EventsList", params: { organizerId: item.organizerId } })}
+          >
+            {item.profilePictureUrl ? (
+              <Image source={{ uri: item.profilePictureUrl }} style={styles.avatar} />
+            ) : (
+              <View style={[styles.avatar, styles.avatarPlaceholder]}>
+                <Text style={[styles.avatarText, { color: theme.colors.mutedForeground }]}>
+                  {[item.firstName, item.lastName].filter(Boolean).map((s) => (s ?? "").charAt(0)).join("") || "?"}
+                </Text>
+              </View>
+            )}
+            <Text style={[styles.name, { color: theme.colors.foreground }]}>
+              {[item.firstName, item.lastName].filter(Boolean).join(" ") || "Organizer"}
+            </Text>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  centered: { flex: 1, justifyContent: "center", alignItems: "center" },
+  empty: { padding: 24 },
+  emptyTitle: { fontSize: 18, fontWeight: "600", marginBottom: 8 },
+  emptyDesc: { fontSize: 14, textAlign: "center" },
+  list: { padding: staticTheme.spacing.md },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 16,
+    borderRadius: staticTheme.radius.lg,
+    marginBottom: 12,
+    borderWidth: 1,
+  },
+  avatar: { width: 44, height: 44, borderRadius: 22 },
+  avatarPlaceholder: { justifyContent: "center", alignItems: "center" },
+  avatarText: { fontSize: 16, fontWeight: "600" },
+  name: { marginLeft: 12, fontSize: 16, fontWeight: "600", flex: 1 },
+});

--- a/eventpro-mobile/src/screens/HomeScreen.tsx
+++ b/eventpro-mobile/src/screens/HomeScreen.tsx
@@ -14,6 +14,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "../context/AuthContext";
 import type { Event } from "@eventpro/shared";
 import { useTheme } from "../contexts/ThemeContext";
+import { EventCard } from "../components/EventCard";
 import { lightTheme } from "../theme";
 
 const CATEGORIES = [
@@ -198,39 +199,13 @@ export function HomeScreen({ navigation }: { navigation: any }) {
             <Text style={[styles.loadingText, { color: theme.colors.mutedForeground }]}>Loading…</Text>
           </View>
         ) : trendingEvents.length > 0 ? (
-          trendingEvents.map((event) => {
-            const imageUrl = (event as any).imageUrl ?? (event as any).coverImageUrl;
-            const startTime = event.startTime ?? (event as any).startDateTime;
-            return (
-              <TouchableOpacity
-                key={event.id}
-                style={[styles.eventCard, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}
-                onPress={() => navigation.navigate("EventDetail", { eventId: event.id })}
-                activeOpacity={0.8}
-              >
-                {imageUrl ? (
-                  <Image source={{ uri: imageUrl }} style={styles.eventImage} resizeMode="cover" />
-                ) : (
-                  <View style={[styles.eventImagePlaceholder, { backgroundColor: theme.colors.muted }]}>
-                    <Ionicons name="calendar-outline" size={36} color={theme.colors.mutedForeground} />
-                  </View>
-                )}
-                <View style={styles.eventCardBody}>
-                  <Text style={[styles.eventName, { color: theme.colors.foreground }]} numberOfLines={2}>{event.name}</Text>
-                  <Text style={[styles.eventDate, { color: theme.colors.mutedForeground }]}>
-                    {startTime
-                      ? new Date(startTime).toLocaleDateString(undefined, {
-                          weekday: "short",
-                          month: "short",
-                          day: "numeric",
-                          year: "numeric",
-                        })
-                      : ""}
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            );
-          })
+          trendingEvents.map((event) => (
+            <EventCard
+              key={event.id}
+              event={event}
+              onPress={() => navigation.navigate("EventDetail", { eventId: event.id })}
+            />
+          ))
         ) : (
           <View style={[styles.emptyCard, { backgroundColor: theme.colors.muted }]}>
             <Ionicons name="ticket-outline" size={40} color={theme.colors.mutedForeground} />
@@ -259,32 +234,13 @@ export function HomeScreen({ navigation }: { navigation: any }) {
             <ActivityIndicator size="small" color={theme.colors.primary} />
           </View>
         ) : upcomingEvents.length > 0 ? (
-          upcomingEvents.map((event) => {
-            const imageUrl = (event as any).imageUrl ?? (event as any).coverImageUrl;
-            const startTime = event.startTime ?? (event as any).startDateTime;
-            return (
-              <TouchableOpacity
-                key={event.id}
-                style={[styles.eventCard, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}
-                onPress={() => navigation.navigate("EventDetail", { eventId: event.id })}
-                activeOpacity={0.8}
-              >
-                {imageUrl ? (
-                  <Image source={{ uri: imageUrl }} style={styles.eventImage} resizeMode="cover" />
-                ) : (
-                  <View style={[styles.eventImagePlaceholder, { backgroundColor: theme.colors.muted }]}>
-                    <Ionicons name="calendar-outline" size={36} color={theme.colors.mutedForeground} />
-                  </View>
-                )}
-                <View style={styles.eventCardBody}>
-                  <Text style={[styles.eventName, { color: theme.colors.foreground }]} numberOfLines={2}>{event.name}</Text>
-                  <Text style={[styles.eventDate, { color: theme.colors.mutedForeground }]}>
-                    {startTime ? new Date(startTime).toLocaleDateString(undefined, { dateStyle: "medium" }) : ""}
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            );
-          })
+          upcomingEvents.map((event) => (
+            <EventCard
+              key={event.id}
+              event={event}
+              onPress={() => navigation.navigate("EventDetail", { eventId: event.id })}
+            />
+          ))
         ) : (
           <View style={[styles.emptyCardSmall, { backgroundColor: theme.colors.muted }]}>
             <Ionicons name="calendar-outline" size={32} color={theme.colors.mutedForeground} />

--- a/eventpro-mobile/src/screens/LoginScreen.tsx
+++ b/eventpro-mobile/src/screens/LoginScreen.tsx
@@ -12,9 +12,71 @@ import {
   ScrollView,
 } from "react-native";
 import { useAuth } from "../context/AuthContext";
-import { theme } from "../theme";
+import { useTheme } from "../contexts/ThemeContext";
+import type { Theme } from "../theme";
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    scrollContent: { flexGrow: 1, justifyContent: "center", padding: theme.spacing.lg, paddingVertical: 40 },
+    card: {
+      backgroundColor: theme.colors.card,
+      borderRadius: theme.radius.lg,
+      padding: theme.spacing.lg,
+      shadowColor: "#000",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.08,
+      shadowRadius: 8,
+      elevation: 3,
+    },
+    iconBox: {
+      width: 48,
+      height: 48,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.primary,
+      alignSelf: "center",
+      alignItems: "center",
+      justifyContent: "center",
+      marginBottom: theme.spacing.md,
+    },
+    iconText: { color: theme.colors.primaryForeground, fontSize: 18, fontWeight: "700" },
+    title: { fontSize: 22, fontWeight: "700", textAlign: "center", marginBottom: 4, color: theme.colors.foreground },
+    subtitle: { fontSize: 14, color: theme.colors.mutedForeground, textAlign: "center", marginBottom: 24 },
+    label: { fontSize: 14, fontWeight: "600", marginBottom: 6, color: theme.colors.foreground },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.radius.md,
+      padding: 14,
+      fontSize: 16,
+      marginBottom: 16,
+      backgroundColor: theme.colors.card,
+      color: theme.colors.foreground,
+    },
+    passwordRow: { position: "relative" as const, marginBottom: 8 },
+    passwordInput: { marginBottom: 0, paddingRight: 56 },
+    eyeButton: { position: "absolute" as const, right: 12, top: 0, bottom: 0, justifyContent: "center" },
+    eyeText: { fontSize: 14, color: theme.colors.mutedForeground },
+    forgotLink: { alignSelf: "flex-end", marginBottom: 16 },
+    forgotText: { fontSize: 14, color: theme.colors.primary },
+    verifyLink: { alignSelf: "center", marginTop: 12 },
+    button: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      padding: 16,
+      alignItems: "center",
+    },
+    buttonDisabled: { opacity: 0.7 },
+    buttonText: { color: theme.colors.primaryForeground, fontSize: 16, fontWeight: "600" },
+    footer: { flexDirection: "row", justifyContent: "center", alignItems: "center", marginTop: 20 },
+    footerText: { fontSize: 14, color: theme.colors.mutedForeground },
+    footerLink: { fontSize: 14, color: theme.colors.primary, fontWeight: "600" },
+  });
+}
 
 export function LoginScreen({ navigation }: { navigation: { navigate: (name: string) => void } }) {
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
   const { login } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -29,6 +91,7 @@ export function LoginScreen({ navigation }: { navigation: { navigate: (name: str
     setLoading(true);
     try {
       await login({ email: email.trim(), password });
+      (navigation as any).getParent()?.navigate("Main");
     } catch (err: unknown) {
       const e = err as { code?: string; message?: string; response?: { data?: { message?: string } }; isAxiosError?: boolean };
       const isNetworkError =
@@ -121,60 +184,3 @@ export function LoginScreen({ navigation }: { navigation: { navigate: (name: str
     </KeyboardAvoidingView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
-  scrollContent: { flexGrow: 1, justifyContent: "center", padding: theme.spacing.lg, paddingVertical: 40 },
-  card: {
-    backgroundColor: theme.colors.card,
-    borderRadius: theme.radius.lg,
-    padding: theme.spacing.lg,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 3,
-  },
-  iconBox: {
-    width: 48,
-    height: 48,
-    borderRadius: theme.radius.md,
-    backgroundColor: theme.colors.primary,
-    alignSelf: "center",
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: theme.spacing.md,
-  },
-  iconText: { color: theme.colors.primaryForeground, fontSize: 18, fontWeight: "700" },
-  title: { fontSize: 22, fontWeight: "700", textAlign: "center", marginBottom: 4, color: theme.colors.foreground },
-  subtitle: { fontSize: 14, color: theme.colors.mutedForeground, textAlign: "center", marginBottom: 24 },
-  label: { fontSize: 14, fontWeight: "600", marginBottom: 6, color: theme.colors.foreground },
-  input: {
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: theme.radius.md,
-    padding: 14,
-    fontSize: 16,
-    marginBottom: 16,
-    backgroundColor: theme.colors.card,
-    color: theme.colors.foreground,
-  },
-  passwordRow: { position: "relative" as const, marginBottom: 8 },
-  passwordInput: { marginBottom: 0, paddingRight: 56 },
-  eyeButton: { position: "absolute" as const, right: 12, top: 0, bottom: 0, justifyContent: "center" },
-  eyeText: { fontSize: 14, color: theme.colors.mutedForeground },
-  forgotLink: { alignSelf: "flex-end", marginBottom: 16 },
-  forgotText: { fontSize: 14, color: theme.colors.primary },
-  verifyLink: { alignSelf: "center", marginTop: 12 },
-  button: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: theme.radius.md,
-    padding: 16,
-    alignItems: "center",
-  },
-  buttonDisabled: { opacity: 0.7 },
-  buttonText: { color: theme.colors.primaryForeground, fontSize: 16, fontWeight: "600" },
-  footer: { flexDirection: "row", justifyContent: "center", alignItems: "center", marginTop: 20 },
-  footerText: { fontSize: 14, color: theme.colors.mutedForeground },
-  footerLink: { fontSize: 14, color: theme.colors.primary, fontWeight: "600" },
-});

--- a/eventpro-mobile/src/screens/PricingScreen.tsx
+++ b/eventpro-mobile/src/screens/PricingScreen.tsx
@@ -3,11 +3,13 @@ import { View, Text, ScrollView, StyleSheet, TouchableOpacity, ActivityIndicator
 import Constants from "expo-constants";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "../context/AuthContext";
-import { theme } from "../theme";
+import { useTheme } from "../contexts/ThemeContext";
+import { theme as staticTheme } from "../theme";
 
 const WEB_URL = Constants.expoConfig?.extra?.webUrl ?? process.env.EXPO_PUBLIC_WEB_URL ?? "http://localhost:5173";
 
 export function PricingScreen({ navigation }: { navigation?: any }) {
+  const { theme } = useTheme();
   const { api, user } = useAuth();
   const [upgrading, setUpgrading] = useState(false);
   const currentTier = (user?.subscriptionTier ?? "BASIC").toUpperCase();
@@ -75,9 +77,9 @@ export function PricingScreen({ navigation }: { navigation?: any }) {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  content: { padding: theme.spacing.lg },
+  content: { padding: staticTheme.spacing.lg },
   title: { fontSize: 24, fontWeight: "700", marginBottom: 20 },
-  card: { padding: 20, borderRadius: theme.radius.lg, marginBottom: 12, borderWidth: 1 },
+  card: { padding: 20, borderRadius: staticTheme.radius.lg, marginBottom: 12, borderWidth: 1 },
   tier: { fontSize: 18, fontWeight: "600" },
   price: { fontSize: 20, fontWeight: "700", marginTop: 4 },
   desc: { fontSize: 14, marginTop: 8 },
@@ -89,7 +91,7 @@ const styles = StyleSheet.create({
     marginTop: 14,
     paddingVertical: 12,
     paddingHorizontal: 20,
-    borderRadius: theme.radius.md,
+    borderRadius: staticTheme.radius.md,
   },
   upgradeBtnText: { fontSize: 16, fontWeight: "600" },
   footnote: { fontSize: 13, marginTop: 24, textAlign: "center" },

--- a/eventpro-mobile/src/screens/ProfileScreen.tsx
+++ b/eventpro-mobile/src/screens/ProfileScreen.tsx
@@ -7,13 +7,17 @@ import {
   ScrollView,
   ActivityIndicator,
   Linking,
+  Image,
+  Alert,
 } from "react-native";
 import Constants from "expo-constants";
+import * as ImagePicker from "expo-image-picker";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "../context/AuthContext";
 import type { OrganizerSummary } from "@eventpro/shared";
 import { useTheme } from "../contexts/ThemeContext";
 import { lightTheme } from "../theme";
+import { uploadProfilePicture as uploadProfilePictureMobile } from "../lib/mobileApi";
 
 const WEB_URL = Constants.expoConfig?.extra?.webUrl ?? process.env.EXPO_PUBLIC_WEB_URL ?? "http://localhost:5173";
 
@@ -35,6 +39,7 @@ export function ProfileScreen({ navigation }: { navigation: any }) {
   const [summary, setSummary] = useState<OrganizerSummary | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [rejectionReason, setRejectionReason] = useState<string | null>(null);
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
 
   const isOrganizer = hasRole("ORGANIZER");
   const verificationStatus = user?.verificationStatus ?? "NOT_STARTED";
@@ -87,12 +92,71 @@ export function ProfileScreen({ navigation }: { navigation: any }) {
     return user?.email?.[0]?.toUpperCase() ?? "U";
   };
 
+  const handleChangePhoto = useCallback(async () => {
+    if (uploadingPhoto) return;
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert("Permission needed", "Allow access to your photos to set a profile picture.");
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    });
+    if (result.canceled || !result.assets?.[0]?.uri) return;
+    setUploadingPhoto(true);
+    try {
+      const asset = result.assets[0];
+      await uploadProfilePictureMobile({
+        uri: asset.uri,
+        type: asset.mimeType ?? "image/jpeg",
+        name: asset.fileName ?? "profile.jpg",
+      });
+      await refreshUser();
+    } catch (e) {
+      Alert.alert("Upload failed", "Could not update profile picture. Try again.");
+    } finally {
+      setUploadingPhoto(false);
+    }
+  }, [refreshUser, uploadingPhoto]);
+
   const displayName = [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "User";
   const specialtyLabel = user?.culturalNiche
     ? `Focus: ${user.culturalNiche}`
     : isOrganizer
       ? "Focus: Cultural & Community Events"
       : null;
+
+  // Guest view: same as web – browse first, sign in only when needed
+  if (!user) {
+    return (
+      <View style={[styles.guestContainer, { backgroundColor: theme.colors.background }]}>
+        <View style={[styles.guestCard, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}>
+          <View style={[styles.guestIconWrap, { backgroundColor: theme.colors.primary + "20" }]}>
+            <Ionicons name="person-outline" size={48} color={theme.colors.primary} />
+          </View>
+          <Text style={[styles.guestTitle, { color: theme.colors.foreground }]}>Welcome to EventPro</Text>
+          <Text style={[styles.guestSubtitle, { color: theme.colors.mutedForeground }]}>
+            Sign in to get tickets, follow organizers, and manage your orders.
+          </Text>
+          <TouchableOpacity
+            style={[styles.guestButton, { backgroundColor: theme.colors.primary }]}
+            onPress={() => (navigation as any).getParent()?.getParent()?.navigate("Auth", { screen: "Login" })}
+          >
+            <Text style={[styles.guestButtonText, { color: theme.colors.primaryForeground }]}>Sign in</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.guestButtonOutline, { borderColor: theme.colors.primary }]}
+            onPress={() => (navigation as any).getParent()?.getParent()?.navigate("Auth", { screen: "SignUp" })}
+          >
+            <Text style={[styles.guestButtonOutlineText, { color: theme.colors.primary }]}>Create account</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
 
   return (
     <ScrollView
@@ -103,9 +167,27 @@ export function ProfileScreen({ navigation }: { navigation: any }) {
       {/* Hero card */}
       <View style={[styles.heroCard, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}>
         <View style={styles.heroRow}>
-          <View style={[styles.avatarWrap, { backgroundColor: theme.colors.primary + "30" }]}>
-            <Text style={[styles.avatarText, { color: theme.colors.primary }]}>{getInitials()}</Text>
-          </View>
+          <TouchableOpacity
+            onPress={handleChangePhoto}
+            disabled={uploadingPhoto}
+            style={[styles.avatarWrap, { backgroundColor: theme.colors.primary + "30" }]}
+            activeOpacity={0.8}
+          >
+            {user?.profilePictureUrl ? (
+              <Image key={user.profilePictureUrl} source={{ uri: user.profilePictureUrl }} style={styles.avatarImage} />
+            ) : (
+              <Text style={[styles.avatarText, { color: theme.colors.primary }]}>{getInitials()}</Text>
+            )}
+            {uploadingPhoto ? (
+              <View style={styles.avatarOverlay}>
+                <ActivityIndicator size="small" color="#fff" />
+              </View>
+            ) : (
+              <View style={styles.avatarBadge}>
+                <Ionicons name="camera" size={16} color={theme.colors.primaryForeground} />
+              </View>
+            )}
+          </TouchableOpacity>
           <View style={styles.heroMain}>
             <Text style={[styles.heroName, { color: theme.colors.foreground }]}>{displayName}</Text>
             {specialtyLabel ? (
@@ -393,6 +475,11 @@ export function ProfileScreen({ navigation }: { navigation: any }) {
           <Text style={[styles.linkText, { color: theme.colors.foreground }]}>Order history</Text>
           <Ionicons name="chevron-forward" size={20} color={theme.colors.mutedForeground} />
         </TouchableOpacity>
+        <TouchableOpacity style={[styles.linkRow, { borderBottomColor: theme.colors.border }]} onPress={() => navigation.navigate("Following")}>
+          <Ionicons name="heart-outline" size={22} color={theme.colors.foreground} />
+          <Text style={[styles.linkText, { color: theme.colors.foreground }]}>Following</Text>
+          <Ionicons name="chevron-forward" size={20} color={theme.colors.mutedForeground} />
+        </TouchableOpacity>
         <TouchableOpacity style={[styles.linkRow, { borderBottomColor: theme.colors.border }]} onPress={() => navigation.navigate("Pricing")}>
           <Ionicons name="pricetag-outline" size={22} color={theme.colors.foreground} />
           <Text style={[styles.linkText, { color: theme.colors.foreground }]}>Pricing</Text>
@@ -418,8 +505,27 @@ const styles = StyleSheet.create({
     marginBottom: lightTheme.spacing.md,
   },
   heroRow: { flexDirection: "row", alignItems: "flex-start", gap: 16 },
-  avatarWrap: { width: 72, height: 72, borderRadius: 36, justifyContent: "center", alignItems: "center" },
+  avatarWrap: { width: 72, height: 72, borderRadius: 36, justifyContent: "center", alignItems: "center", overflow: "hidden" },
+  avatarImage: { width: 72, height: 72, borderRadius: 36 },
   avatarText: { fontSize: 24, fontWeight: "700" },
+  avatarOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: 36,
+  },
+  avatarBadge: {
+    position: "absolute",
+    right: 0,
+    bottom: 0,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: lightTheme.colors.primary,
+    justifyContent: "center",
+    alignItems: "center",
+  },
   heroMain: { flex: 1 },
   heroName: { fontSize: 22, fontWeight: "700", marginBottom: 4 },
   specialty: { fontSize: 14, marginBottom: 8 },
@@ -476,4 +582,13 @@ const styles = StyleSheet.create({
   },
   linkText: { flex: 1, fontSize: 16 },
   logoutText: { flex: 1, fontSize: 16 },
+  guestContainer: { flex: 1, justifyContent: "center", alignItems: "center", padding: lightTheme.spacing.lg },
+  guestCard: { width: "100%", maxWidth: 360, padding: 28, borderRadius: lightTheme.radius.lg, borderWidth: 1, alignItems: "center" },
+  guestIconWrap: { width: 88, height: 88, borderRadius: 44, justifyContent: "center", alignItems: "center", marginBottom: 20 },
+  guestTitle: { fontSize: 22, fontWeight: "700", marginBottom: 8, textAlign: "center" },
+  guestSubtitle: { fontSize: 15, textAlign: "center", marginBottom: 24, lineHeight: 22 },
+  guestButton: { width: "100%", paddingVertical: 14, borderRadius: lightTheme.radius.md, alignItems: "center", marginBottom: 12 },
+  guestButtonText: { fontSize: 16, fontWeight: "600" },
+  guestButtonOutline: { width: "100%", paddingVertical: 14, borderRadius: lightTheme.radius.md, borderWidth: 2, alignItems: "center" },
+  guestButtonOutlineText: { fontSize: 16, fontWeight: "600" },
 });

--- a/eventpro-mobile/src/screens/SignUpScreen.tsx
+++ b/eventpro-mobile/src/screens/SignUpScreen.tsx
@@ -12,7 +12,8 @@ import {
 } from "react-native";
 import { useAuth } from "../context/AuthContext";
 import type { UserRole } from "@eventpro/shared";
-import { theme } from "../theme";
+import { useTheme } from "../contexts/ThemeContext";
+import type { Theme } from "../theme";
 
 /** Extract a user-friendly message from signup API error (backend sends message + optional fields). */
 function getSignUpErrorMessage(err: unknown): string {
@@ -58,7 +59,77 @@ function getSignUpErrorMessage(err: unknown): string {
   return "Sign up failed. Check your entries and try again.";
 }
 
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    scrollContent: { padding: theme.spacing.lg, paddingVertical: 24, paddingBottom: 40 },
+    card: {
+      backgroundColor: theme.colors.card,
+      borderRadius: theme.radius.lg,
+      padding: theme.spacing.lg,
+      shadowColor: "#000",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.08,
+      shadowRadius: 8,
+      elevation: 3,
+    },
+    iconBox: {
+      width: 48,
+      height: 48,
+      borderRadius: theme.radius.md,
+      backgroundColor: theme.colors.primary,
+      alignSelf: "center",
+      alignItems: "center",
+      justifyContent: "center",
+      marginBottom: theme.spacing.md,
+    },
+    iconText: { color: theme.colors.primaryForeground, fontSize: 18, fontWeight: "700" },
+    title: { fontSize: 22, fontWeight: "700", textAlign: "center", marginBottom: 4, color: theme.colors.foreground },
+    subtitle: { fontSize: 14, color: theme.colors.mutedForeground, textAlign: "center", marginBottom: 24 },
+    label: { fontSize: 14, fontWeight: "600", marginBottom: 6, color: theme.colors.foreground },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.radius.md,
+      padding: 14,
+      fontSize: 16,
+      marginBottom: 16,
+      backgroundColor: theme.colors.card,
+      color: theme.colors.foreground,
+    },
+    row: { flexDirection: "row", gap: 12 },
+    half: { flex: 1 },
+    roleRow: { flexDirection: "row", gap: 12, marginBottom: 16 },
+    roleBtn: {
+      flex: 1,
+      paddingVertical: 12,
+      paddingHorizontal: 16,
+      borderRadius: theme.radius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      alignItems: "center",
+    },
+    roleBtnActive: { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
+    roleBtnText: { fontSize: 14, color: theme.colors.mutedForeground },
+    roleBtnTextActive: { color: theme.colors.primaryForeground, fontWeight: "600" },
+    button: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.radius.md,
+      padding: 16,
+      alignItems: "center",
+      marginTop: 8,
+    },
+    buttonDisabled: { opacity: 0.7 },
+    buttonText: { color: theme.colors.primaryForeground, fontSize: 16, fontWeight: "600" },
+    footer: { flexDirection: "row", justifyContent: "center", alignItems: "center", marginTop: 20 },
+    footerText: { fontSize: 14, color: theme.colors.mutedForeground },
+    footerLink: { fontSize: 14, color: theme.colors.primary, fontWeight: "600" },
+  });
+}
+
 export function SignUpScreen({ navigation }: { navigation: { navigate: (name: string) => void } }) {
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
   const { signUp } = useAuth();
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -224,69 +295,3 @@ export function SignUpScreen({ navigation }: { navigation: { navigate: (name: st
     </KeyboardAvoidingView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
-  scrollContent: { padding: theme.spacing.lg, paddingVertical: 24, paddingBottom: 40 },
-  card: {
-    backgroundColor: theme.colors.card,
-    borderRadius: theme.radius.lg,
-    padding: theme.spacing.lg,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 3,
-  },
-  iconBox: {
-    width: 48,
-    height: 48,
-    borderRadius: theme.radius.md,
-    backgroundColor: theme.colors.primary,
-    alignSelf: "center",
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: theme.spacing.md,
-  },
-  iconText: { color: theme.colors.primaryForeground, fontSize: 18, fontWeight: "700" },
-  title: { fontSize: 22, fontWeight: "700", textAlign: "center", marginBottom: 4, color: theme.colors.foreground },
-  subtitle: { fontSize: 14, color: theme.colors.mutedForeground, textAlign: "center", marginBottom: 24 },
-  label: { fontSize: 14, fontWeight: "600", marginBottom: 6, color: theme.colors.foreground },
-  input: {
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: theme.radius.md,
-    padding: 14,
-    fontSize: 16,
-    marginBottom: 16,
-    backgroundColor: theme.colors.card,
-    color: theme.colors.foreground,
-  },
-  row: { flexDirection: "row", gap: 12 },
-  half: { flex: 1 },
-  roleRow: { flexDirection: "row", gap: 12, marginBottom: 16 },
-  roleBtn: {
-    flex: 1,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: theme.radius.md,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    alignItems: "center",
-  },
-  roleBtnActive: { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
-  roleBtnText: { fontSize: 14, color: theme.colors.mutedForeground },
-  roleBtnTextActive: { color: theme.colors.primaryForeground, fontWeight: "600" },
-  button: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: theme.radius.md,
-    padding: 16,
-    alignItems: "center",
-    marginTop: 8,
-  },
-  buttonDisabled: { opacity: 0.7 },
-  buttonText: { color: theme.colors.primaryForeground, fontSize: 16, fontWeight: "600" },
-  footer: { flexDirection: "row", justifyContent: "center", alignItems: "center", marginTop: 20 },
-  footerText: { fontSize: 14, color: theme.colors.mutedForeground },
-  footerLink: { fontSize: 14, color: theme.colors.primary, fontWeight: "600" },
-});

--- a/eventpro-mobile/src/screens/VerifyScreen.tsx
+++ b/eventpro-mobile/src/screens/VerifyScreen.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { theme } from "../theme";
+import { useTheme } from "../contexts/ThemeContext";
+import { theme as staticTheme } from "../theme";
 
 /**
  * Shown after sign-up or when user opens the verify-email link.
  * Backend email verification flow can be wired when available.
  */
 export function VerifyScreen({ navigation }: { navigation: any }) {
+  const { theme } = useTheme();
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <View style={[styles.card, { backgroundColor: theme.colors.card, borderColor: theme.colors.border }]}>
@@ -30,11 +32,11 @@ export function VerifyScreen({ navigation }: { navigation: any }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: theme.spacing.lg, justifyContent: "center" },
-  card: { padding: theme.spacing.xl, borderRadius: theme.radius.lg, borderWidth: 1, alignItems: "center" },
+  container: { flex: 1, padding: staticTheme.spacing.lg, justifyContent: "center" },
+  card: { padding: staticTheme.spacing.xl, borderRadius: staticTheme.radius.lg, borderWidth: 1, alignItems: "center" },
   iconWrap: { width: 72, height: 72, borderRadius: 36, justifyContent: "center", alignItems: "center", marginBottom: 16 },
   title: { fontSize: 22, fontWeight: "700", marginBottom: 12, textAlign: "center" },
   desc: { fontSize: 15, textAlign: "center", marginBottom: 24, paddingHorizontal: 8 },
-  primaryBtn: { paddingVertical: 14, paddingHorizontal: 24, borderRadius: theme.radius.md },
+  primaryBtn: { paddingVertical: 14, paddingHorizontal: 24, borderRadius: staticTheme.radius.md },
   primaryBtnText: { fontSize: 16, fontWeight: "600" },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
-        "react": "^18.3.1",
+        "react": "19.1.0",
         "react-day-picker": "^8.10.1",
-        "react-dom": "^18.3.1",
+        "react-dom": "19.1.0",
         "react-hook-form": "^7.61.1",
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^6.30.1",
@@ -76,8 +76,8 @@
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^22.16.5",
-        "@types/react": "^18.3.23",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "~19.1.10",
+        "@types/react-dom": "~19.1.10",
         "@vitejs/plugin-react-swc": "^3.11.0",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.32.0",
@@ -94,61 +94,6 @@
         "vitest": "^3.2.4"
       }
     },
-    "eventpro-frontend/node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "eventpro-frontend/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "eventpro-frontend/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "eventpro-frontend/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "eventpro-frontend/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "eventpro-mobile": {
       "version": "0.1.0",
       "dependencies": {
@@ -159,6 +104,7 @@
         "expo": "~54.0.0",
         "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
+        "expo-image-picker": "~16.0.3",
         "expo-secure-store": "~15.0.8",
         "expo-status-bar": "~3.0.9",
         "jsdom": "28.1.0",
@@ -293,6 +239,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1823,6 +1770,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1861,6 +1809,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -5498,6 +5447,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.33.tgz",
       "integrity": "sha512-DpFdWGcgLajKZ1TuIvDNQsblN2QaUFWpTQaB8v7WRP9Mix8H/6TFoIrZd93pbymI2hybd6UYrD+lI408eWVcfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.16.1",
         "escape-string-regexp": "^4.0.0",
@@ -5947,6 +5897,7 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.9.0.tgz",
       "integrity": "sha512-OJkXvUI5GAc56QdiSRimQDvWYEqn475J+oj8RzRtFTCPtkJNO2TWW619oDY+nn1ExR+2tCVTQuRQBbR4dRugww==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -6297,8 +6248,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6474,16 +6424,10 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.17",
@@ -6491,6 +6435,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6499,8 +6444,8 @@
       "version": "19.1.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.11.tgz",
       "integrity": "sha512-3BKc/yGdNTYQVVw4idqHtSOcFsgGuBbMveKCOgF8wQ5QtrYOc3jDIlzg3jef04zcXFIHLelyGlj0T+BJ8+KN+w==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -6572,6 +6517,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -7019,6 +6965,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7628,6 +7575,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8381,6 +8329,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -8550,8 +8499,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8620,7 +8568,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -8816,6 +8765,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9053,6 +9003,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -9164,6 +9115,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -9171,6 +9123,27 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
+      "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.0.6.tgz",
+      "integrity": "sha512-HN4xZirFjsFDIsWFb12AZh19fRzuvZjj2ll17cGr19VNRP06S/VPQU3Tdccn5vwUzQhOBlLu704CnNm278boiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -10461,6 +10434,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10494,6 +10468,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -10664,6 +10639,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11107,7 +11083,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12217,6 +12192,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12396,7 +12372,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12412,7 +12387,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12425,8 +12399,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/proc-log": {
       "version": "4.2.0",
@@ -12593,6 +12566,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12672,6 +12646,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
       "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12694,6 +12669,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -12761,6 +12737,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -12771,6 +12748,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -12869,6 +12847,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13976,6 +13955,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14076,6 +14056,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -14366,6 +14347,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14646,6 +14628,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15624,6 +15607,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/packages/eventpro-shared/src/createApiClient.ts
+++ b/packages/eventpro-shared/src/createApiClient.ts
@@ -16,6 +16,7 @@ import type {
   Event,
   EventAddon,
   EventSales,
+  FollowedOrganizer,
   GuestConfirmPaymentRequest,
   LoginRequest,
   NotificationPreferences,
@@ -52,12 +53,14 @@ export interface EventProApi {
   signUp: (data: SignUpRequest) => Promise<void>;
   getCurrentUser: () => Promise<User>;
   updateUser: (data: UpdateUserRequest) => Promise<User>;
+  uploadProfilePicture: (file: File | { uri: string; type?: string; name?: string }) => Promise<string>;
   removeAccessToken: () => void | Promise<void>;
 
   // Public events
-  getEvents: (page?: number, size?: number, keyword?: string) => Promise<Event[]>;
+  getEvents: (page?: number, size?: number, keyword?: string, organizerId?: string) => Promise<Event[]>;
   getEventsByCategory: (category: string) => Promise<Event[]>;
   getEvent: (id: string) => Promise<Event>;
+  contactOrganizer: (eventId: string, body: { senderEmail: string; senderName?: string; message: string }) => Promise<void>;
   getTicketTypes: (eventId: string) => Promise<TicketType[]>;
   getEventAddons: (eventId: string) => Promise<EventAddon[]>;
 
@@ -89,6 +92,9 @@ export interface EventProApi {
   updateMyNotificationPreferences: (data: { emailEnabled?: boolean; smsEnabled?: boolean; pushEnabled?: boolean }) => Promise<NotificationPreferences>;
 
   // Organizer
+  getFollowing: () => Promise<FollowedOrganizer[]>;
+  followOrganizer: (organizerId: string) => Promise<void>;
+  unfollowOrganizer: (organizerId: string) => Promise<void>;
   getOrganizerSummary: () => Promise<OrganizerSummary>;
   getOrganizerEvents: () => Promise<Event[]>;
   publishEvent: (eventId: string) => Promise<Event>;
@@ -172,14 +178,31 @@ export function createEventProApi(config: EventProApiConfig): EventProApi {
     async updateUser(data: UpdateUserRequest) {
       return getData(await api.put<ApiResponse<User>>("/api/v1/users/me", data));
     },
+    async uploadProfilePicture(file: File | { uri: string; type?: string; name?: string }) {
+      const formData = new FormData();
+      formData.append("image", file as any);
+      const res = await api.post<ApiResponse<{ url: string }>>("/api/v1/users/upload-profile-picture", formData);
+      return res.data.data?.url ?? "";
+    },
+    async getFollowing() {
+      const res = await api.get<ApiResponse<FollowedOrganizer[]>>("/api/v1/users/me/following");
+      return res.data.data ?? [];
+    },
+    async followOrganizer(organizerId: string) {
+      await api.post<ApiResponse<null>>(`/api/v1/users/me/following/${organizerId}`);
+    },
+    async unfollowOrganizer(organizerId: string) {
+      await api.delete<ApiResponse<null>>(`/api/v1/users/me/following/${organizerId}`);
+    },
     async removeAccessToken() {
       const remove = config.removeAccessToken();
       if (isPromise(remove)) await remove;
     },
 
-    async getEvents(page = 1, size = 20, keyword?: string) {
-      const q = [`page=${page - 1}`, `size=${size}`];
+    async getEvents(page = 1, size = 20, keyword?: string, organizerId?: string) {
+      const q = [`page=${page}`, `size=${size}`];
       if (keyword != null && keyword !== "") q.push(`keyword=${encodeURIComponent(keyword)}`);
+      if (organizerId != null && organizerId !== "") q.push(`organizerId=${encodeURIComponent(organizerId)}`);
       const query = q.join("&");
       const res = await api.get<ApiResponse<{ content: Event[] }>>(`/api/v1/events?${query}`);
       return res.data.data?.content ?? [];
@@ -190,6 +213,9 @@ export function createEventProApi(config: EventProApiConfig): EventProApi {
     },
     async getEvent(id: string) {
       return getData(await api.get<ApiResponse<Event>>(`/api/v1/events/${id}`));
+    },
+    async contactOrganizer(eventId: string, body: { senderEmail: string; senderName?: string; message: string }) {
+      await api.post<ApiResponse<null>>(`/api/v1/events/${eventId}/contact`, body);
     },
     async getTicketTypes(eventId: string) {
       const res = await api.get<ApiResponse<TicketType[]>>(`/api/v1/events/${eventId}/ticket-types`);

--- a/packages/eventpro-shared/src/types.ts
+++ b/packages/eventpro-shared/src/types.ts
@@ -40,6 +40,7 @@ export interface Event {
   title?: string;
   description?: string;
   imageUrl?: string;
+  additionalImageUrls?: string[] | null;
   promotionalVideoUrl?: string;
   eventPageTemplate?: EventPageTemplate | string;
   marketingEnabled?: boolean;
@@ -49,6 +50,9 @@ export interface Event {
   organizerBrandingLogoUrl?: string | null;
   organizerBrandingPrimaryColor?: string | null;
   organizerBrandingHidePlatform?: boolean;
+  organizerFirstName?: string | null;
+  organizerLastName?: string | null;
+  organizerProfilePictureUrl?: string | null;
   startTime: string;
   endTime: string;
   userId?: string;
@@ -67,6 +71,14 @@ export interface Event {
   category?: string;
   createdAt?: string;
   updatedAt?: string;
+}
+
+/** Organizer in the current user's Following list. */
+export interface FollowedOrganizer {
+  organizerId: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  profilePictureUrl?: string | null;
 }
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
- Event cards on home/events match web (image, category, date/time/venue, Get Tickets)
- Events screen: category filter pills, search, pull-to-refresh
- Guest checkout: CartContext for guest + logged-in; add to cart without login; guest form and reserve/intent on Checkout
- Follow: load only when logged in, normalize organizerId, refetch after follow/unfollow
- Live “X people viewing now” badge on event detail and cards (simulated)
- Dark mode applied across stacks and screens